### PR TITLE
Add random string to target group.

### DIFF
--- a/modules/keycloak/loadbalancer.tf
+++ b/modules/keycloak/loadbalancer.tf
@@ -8,8 +8,14 @@ resource "aws_alb" "main" {
   )
 }
 
+resource "random_string" "alb_prefix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
 resource "aws_alb_target_group" "keycloak_target" {
-  name        = "keycloak-target-group-${var.environment}"
+  name        = "keycloak-target-group-${random_string.alb_prefix.result}-${var.environment}"
   port        = 8080
   protocol    = "HTTP"
   vpc_id      = aws_vpc.main.id


### PR DESCRIPTION
This fixes some weird behaviour in terraform where it complains that the
target group isn't attached to any load balancer listeners.