### PR TITLE
remove rules from default security groups

### DIFF
--- a/modules/keycloak/vpc.tf
+++ b/modules/keycloak/vpc.tf
@@ -10,6 +10,11 @@ resource "aws_vpc" "main" {
   )
 }
 
+# Bring default security group under Terraform management and remove all rules
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}
+
 # Create var.az_count private subnets, each in a different AZ
 resource "aws_subnet" "private" {
   count             = var.az_count

--- a/modules/shared-vpc/root.tf
+++ b/modules/shared-vpc/root.tf
@@ -10,6 +10,11 @@ resource "aws_vpc" "main" {
   )
 }
 
+# Bring default security group under Terraform management and remove all rules
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}
+
 # Create var.az_count private subnets, each in a different AZ
 resource "aws_subnet" "private" {
   count             = var.az_count


### PR DESCRIPTION
AWS automatically creates a default security group with each VPC, which includes an inbound from any rule. It's not possible to delete this default security group. This change brings the default security group under Terraform management and removes all rules.