### PR TITLE
Move git clone into the set up stage.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,6 @@ pipeline {
         choice(name: "STAGE", choices: ["intg", "staging", "prod"], description: "The stage you are deploying Terraform changes to")
     }
     stages {
-        stage('Clone module repositories') {
-            sh "git clone https://github.com/nationalarchives/tdr-terraform-modules.git"
-        }
         stage('Run Terraform build') {
             agent {
                 ecs {
@@ -26,6 +23,7 @@ pipeline {
                 stage('Set up Terraform workspace') {
                     steps {
                         echo 'Initializing Terraform...'
+                        sh "git clone https://github.com/nationalarchives/tdr-terraform-modules.git"
                         sh 'terraform init'
                         //If Terraform workspace exists continue
                         sh "terraform workspace new ${params.STAGE} || true"


### PR DESCRIPTION
Jenkins uses a new temporary directory for each stage so the folder
cloned in the first stage wasn't available for the plan stage. I've
moved the git clone into the plan stage.