### PR TITLE
Remove the prefix from the url.

### DIFF
--- a/modules/transfer-frontend/outputs.tf
+++ b/modules/transfer-frontend/outputs.tf
@@ -3,5 +3,5 @@ output alb_security_group_id {
 }
 
 output "frontend_url" {
-  value = "https://${aws_route53_record.frontend_dns.name}.${var.dns_zone_name_trimmed}"
+  value = "https://${var.dns_zone_name_trimmed}"
 }


### PR DESCRIPTION
The front end dns name is blank so with the url as it was, we were
getting https://.tdr-integration.nationalarchives.gov.uk which doesn't
make sense. This removes it.