### PR TITLE
Remove create log group permission.

### DIFF
--- a/modules/keycloak/flowlogs.tf
+++ b/modules/keycloak/flowlogs.tf
@@ -47,7 +47,6 @@ resource "aws_iam_policy" "keycloak_flowlog_policy" {
 data "aws_iam_policy_document" "keycloak_flowlog_policy" {
   statement {
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",


### PR DESCRIPTION
This is because of an issue where the flow log cloudwatch log groups
were being recreated after terraform destroy was run. This prevented us
from running terraform apply because they already existed. This is
probably due to this github issue
https://github.com/hashicorp/terraform/issues/14750#issuecomment-303337513

The policy doesn't need to be able to create log groups because the log
group is created by terraform and removing this permission prevents it
recreating the log group after terraform destroy.