### PR TITLE
Pass environment to API ECS task

### DIFF
--- a/modules/consignment-api/templates/consignment-api.json.tpl
+++ b/modules/consignment-api/templates/consignment-api.json.tpl
@@ -5,6 +5,10 @@
     "cpu": 0,
     "environment": [
       {
+        "name" : "ENVIRONMENT",
+        "value" : "${app_environment}"
+      },
+      {
         "name" : "AUTH_URL",
         "value" : "${auth_url}"
       },


### PR DESCRIPTION
This will allow us to launch the ECS task with different config, depending on the environment.

The main reason for doing this now is to be able to set different CORS headers in integration vs staging and production, so that we can run a frontend dev environment that connects to the integration API.

https://national-archives.atlassian.net/browse/TDR-138