### PR TITLE
Add keycloak backend checks secret

### DIFF
--- a/modules/keycloak/ecs.tf
+++ b/modules/keycloak/ecs.tf
@@ -23,7 +23,7 @@ data "template_file" "app" {
     password_path                     = aws_ssm_parameter.database_password.name
     admin_user_path                   = aws_ssm_parameter.keycloak_admin_user.name
     admin_password_path               = aws_ssm_parameter.keycloak_admin_password.name
-    frontend_app_client_secret_path                = aws_ssm_parameter.keycloak_frontend_app_client_secret.name
+    frontend_app_client_secret_path   = aws_ssm_parameter.keycloak_frontend_app_client_secret.name
     backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
     frontend_url                      = var.frontend_url
 

--- a/modules/keycloak/ecs.tf
+++ b/modules/keycloak/ecs.tf
@@ -14,17 +14,18 @@ data "template_file" "app" {
   template = file("modules/keycloak/templates/keycloak.json.tpl")
 
   vars = {
-    app_image           = "nationalarchives/tdr-auth-server:${var.environment}"
-    app_port            = local.app_port
-    app_environment     = var.environment
-    aws_region          = var.region
-    url_path            = aws_ssm_parameter.database_url.name
-    username_path       = aws_ssm_parameter.database_username.name
-    password_path       = aws_ssm_parameter.database_password.name
-    admin_user_path     = aws_ssm_parameter.keycloak_admin_user.name
-    admin_password_path = aws_ssm_parameter.keycloak_admin_password.name
-    client_secret_path  = aws_ssm_parameter.keycloak_client_secret.name
-    frontend_url        = var.frontend_url
+    app_image                         = "nationalarchives/tdr-auth-server:${var.environment}"
+    app_port                          = local.app_port
+    app_environment                   = var.environment
+    aws_region                        = var.region
+    url_path                          = aws_ssm_parameter.database_url.name
+    username_path                     = aws_ssm_parameter.database_username.name
+    password_path                     = aws_ssm_parameter.database_password.name
+    admin_user_path                   = aws_ssm_parameter.keycloak_admin_user.name
+    admin_password_path               = aws_ssm_parameter.keycloak_admin_password.name
+    client_secret_path                = aws_ssm_parameter.keycloak_client_secret.name
+    backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
+    frontend_url                      = var.frontend_url
 
   }
 }

--- a/modules/keycloak/ecs.tf
+++ b/modules/keycloak/ecs.tf
@@ -23,7 +23,7 @@ data "template_file" "app" {
     password_path                     = aws_ssm_parameter.database_password.name
     admin_user_path                   = aws_ssm_parameter.keycloak_admin_user.name
     admin_password_path               = aws_ssm_parameter.keycloak_admin_password.name
-    client_secret_path                = aws_ssm_parameter.keycloak_client_secret.name
+    frontend_app_client_secret_path                = aws_ssm_parameter.keycloak_frontend_app_client_secret.name
     backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
     frontend_url                      = var.frontend_url
 

--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -14,8 +14,8 @@ output "auth_url" {
   value = "https://${aws_route53_record.keycloak_dns.name}.${var.dns_zone_name_trimmed}/auth"
 }
 
-output "client_secret_path" {
-  value = aws_ssm_parameter.keycloak_client_secret.name
+output "frontend_app_client_secret_path" {
+  value = aws_ssm_parameter.keycloak_frontend_app_client_secret.name
 }
 
 output "backend_checks_client_secret_path" {

--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -17,3 +17,7 @@ output "auth_url" {
 output "client_secret_path" {
   value = aws_ssm_parameter.keycloak_client_secret.name
 }
+
+output "backend_checks_client_secret_path" {
+  value = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
+}

--- a/modules/keycloak/ssm.tf
+++ b/modules/keycloak/ssm.tf
@@ -4,6 +4,7 @@ resource "random_password" "keycloak_password" {
 }
 
 resource "random_uuid" "client_secret" {}
+resource "random_uuid" "backend_checks_client_secret" {}
 
 resource "aws_ssm_parameter" "database_url" {
   name  = "/${var.environment}/keycloak/database/url"
@@ -39,4 +40,10 @@ resource "aws_ssm_parameter" "keycloak_client_secret" {
   name  = "/${var.environment}/keycloak/client/secret"
   type  = "SecureString"
   value = random_uuid.client_secret.result
+}
+
+resource "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
+  name  = "/${var.environment}/keycloak/backend_checks_client/secret"
+  type  = "SecureString"
+  value = random_uuid.backend_checks_client_secret.result
 }

--- a/modules/keycloak/ssm.tf
+++ b/modules/keycloak/ssm.tf
@@ -3,7 +3,7 @@ resource "random_password" "keycloak_password" {
   special = false
 }
 
-resource "random_uuid" "client_secret" {}
+resource "random_uuid" "frontend_app_client_secret" {}
 resource "random_uuid" "backend_checks_client_secret" {}
 
 resource "aws_ssm_parameter" "database_url" {
@@ -36,10 +36,10 @@ resource "aws_ssm_parameter" "keycloak_admin_user" {
   value = "tdr-keycloak-admin-${var.environment}"
 }
 
-resource "aws_ssm_parameter" "keycloak_client_secret" {
-  name  = "/${var.environment}/keycloak/client/secret"
+resource "aws_ssm_parameter" "keycloak_frontend_app_client_secret" {
+  name  = "/${var.environment}/keycloak/frontend_app_client/secret"
   type  = "SecureString"
-  value = random_uuid.client_secret.result
+  value = random_uuid.frontend_app_client_secret.result
 }
 
 resource "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -27,6 +27,10 @@
       {
         "valueFrom" : "${client_secret_path}",
         "name": "CLIENT_SECRET"
+      },
+      {
+        "valueFrom": "${backend_checks_client_secret_path}",
+        "name": "BACKEND_CHECKS_CLIENT_SECRET"
       }
     ],
     "environment": [

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -25,8 +25,8 @@
         "name": "KEYCLOAK_PASSWORD"
       },
       {
-        "valueFrom" : "${client_secret_path}",
-        "name": "CLIENT_SECRET"
+        "valueFrom" : "${frontend_app_client_secret_path}",
+        "name": "FRONTEND_APP_CLIENT_SECRET"
       },
       {
         "valueFrom": "${backend_checks_client_secret_path}",

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -18,7 +18,7 @@ data "template_file" "app" {
     app_port           = local.app_port
     app_environment    = var.environment
     aws_region         = var.region
-    client_secret_path = var.client_secret_path
+    frontend_app_client_secret_path = var.frontend_app_client_secret_path
     identity_pool_id   = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
   }
 }

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -14,12 +14,13 @@ data "template_file" "app" {
   template = file("modules/transfer-frontend/templates/frontend.json.tpl")
 
   vars = {
-    app_image          = "nationalarchives/tdr-transfer-frontend:${var.environment}"
-    app_port           = local.app_port
-    app_environment    = var.environment
-    aws_region         = var.region
-    client_secret_path = var.client_secret_path
-    identity_pool_id   = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
+    app_image                         = "nationalarchives/tdr-transfer-frontend:${var.environment}"
+    app_port                          = local.app_port
+    app_environment                   = var.environment
+    aws_region                        = var.region
+    client_secret_path                = var.client_secret_path
+    identity_pool_id                  = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
+    backend_checks_client_secret_path = var.backend_checks_client_secret_path
   }
 }
 

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -14,12 +14,12 @@ data "template_file" "app" {
   template = file("modules/transfer-frontend/templates/frontend.json.tpl")
 
   vars = {
-    app_image          = "nationalarchives/tdr-transfer-frontend:${var.environment}"
-    app_port           = local.app_port
-    app_environment    = var.environment
-    aws_region         = var.region
+    app_image                       = "nationalarchives/tdr-transfer-frontend:${var.environment}"
+    app_port                        = local.app_port
+    app_environment                 = var.environment
+    aws_region                      = var.region
     frontend_app_client_secret_path = var.frontend_app_client_secret_path
-    identity_pool_id   = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
+    identity_pool_id                = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
   }
 }
 

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -14,13 +14,12 @@ data "template_file" "app" {
   template = file("modules/transfer-frontend/templates/frontend.json.tpl")
 
   vars = {
-    app_image                         = "nationalarchives/tdr-transfer-frontend:${var.environment}"
-    app_port                          = local.app_port
-    app_environment                   = var.environment
-    aws_region                        = var.region
-    client_secret_path                = var.client_secret_path
-    identity_pool_id                  = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
-    backend_checks_client_secret_path = var.backend_checks_client_secret_path
+    app_image          = "nationalarchives/tdr-transfer-frontend:${var.environment}"
+    app_port           = local.app_port
+    app_environment    = var.environment
+    aws_region         = var.region
+    client_secret_path = var.client_secret_path
+    identity_pool_id   = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
   }
 }
 

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -13,7 +13,7 @@
         "name": "REDIS_HOST"
       },
       {
-        "valueFrom": "${client_secret_path}",
+        "valueFrom": "${frontend_app_client_secret_path}",
         "name": "AUTH_SECRET"
       }
     ],

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -15,6 +15,10 @@
       {
         "valueFrom": "${client_secret_path}",
         "name": "AUTH_SECRET"
+      },
+      {
+        "valueFrom": "${backend_checks_client_secret_path}",
+        "name": "BACKEND_CHECKS_AUTH_SECRET"
       }
     ],
     "environment": [

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -15,10 +15,6 @@
       {
         "valueFrom": "${client_secret_path}",
         "name": "AUTH_SECRET"
-      },
-      {
-        "valueFrom": "${backend_checks_client_secret_path}",
-        "name": "BACKEND_CHECKS_AUTH_SECRET"
       }
     ],
     "environment": [

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -26,4 +26,4 @@ variable "dns_zone_name_trimmed" {}
 
 variable "auth_url" {}
 
-variable "client_secret_path" {}
+variable "frontend_app_client_secret_path" {}

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -27,5 +27,3 @@ variable "dns_zone_name_trimmed" {}
 variable "auth_url" {}
 
 variable "client_secret_path" {}
-
-variable "backend_checks_client_secret_path" {}

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -27,3 +27,5 @@ variable "dns_zone_name_trimmed" {}
 variable "auth_url" {}
 
 variable "client_secret_path" {}
+
+variable "backend_checks_client_secret_path" {}

--- a/root.tf
+++ b/root.tf
@@ -39,23 +39,22 @@ module "consignment_api" {
 }
 
 module "frontend" {
-  app_name                          = "frontend"
-  source                            = "./modules/transfer-frontend"
-  alb_dns_name                      = module.frontend_alb.alb_dns_name
-  alb_target_group_arn              = module.frontend_alb.alb_target_group_arn
-  alb_zone_id                       = module.frontend_alb.alb_zone_id
-  dns_zone_id                       = local.dns_zone_id
-  environment                       = local.environment
-  environment_full_name             = local.environment_full_name_map[local.environment]
-  common_tags                       = local.common_tags
-  region                            = local.region
-  vpc_id                            = module.shared_vpc.vpc_id
-  public_subnets                    = module.shared_vpc.public_subnets
-  private_subnets                   = module.shared_vpc.private_subnets
-  dns_zone_name_trimmed             = local.dns_zone_name_trimmed
-  auth_url                          = module.keycloak.auth_url
-  client_secret_path                = module.keycloak.client_secret_path
-  backend_checks_client_secret_path = module.keycloak.backend_checks_client_secret_path
+  app_name              = "frontend"
+  source                = "./modules/transfer-frontend"
+  alb_dns_name          = module.frontend_alb.alb_dns_name
+  alb_target_group_arn  = module.frontend_alb.alb_target_group_arn
+  alb_zone_id           = module.frontend_alb.alb_zone_id
+  dns_zone_id           = local.dns_zone_id
+  environment           = local.environment
+  environment_full_name = local.environment_full_name_map[local.environment]
+  common_tags           = local.common_tags
+  region                = local.region
+  vpc_id                = module.shared_vpc.vpc_id
+  public_subnets        = module.shared_vpc.public_subnets
+  private_subnets       = module.shared_vpc.private_subnets
+  dns_zone_name_trimmed = local.dns_zone_name_trimmed
+  auth_url              = module.keycloak.auth_url
+  client_secret_path    = module.keycloak.client_secret_path
 }
 
 module "keycloak" {

--- a/root.tf
+++ b/root.tf
@@ -39,22 +39,22 @@ module "consignment_api" {
 }
 
 module "frontend" {
-  app_name              = "frontend"
-  source                = "./modules/transfer-frontend"
-  alb_dns_name          = module.frontend_alb.alb_dns_name
-  alb_target_group_arn  = module.frontend_alb.alb_target_group_arn
-  alb_zone_id           = module.frontend_alb.alb_zone_id
-  dns_zone_id           = local.dns_zone_id
-  environment           = local.environment
-  environment_full_name = local.environment_full_name_map[local.environment]
-  common_tags           = local.common_tags
-  region                = local.region
-  vpc_id                = module.shared_vpc.vpc_id
-  public_subnets        = module.shared_vpc.public_subnets
-  private_subnets       = module.shared_vpc.private_subnets
-  dns_zone_name_trimmed = local.dns_zone_name_trimmed
-  auth_url              = module.keycloak.auth_url
-  frontend_app_client_secret_path    = module.keycloak.frontend_app_client_secret_path
+  app_name                        = "frontend"
+  source                          = "./modules/transfer-frontend"
+  alb_dns_name                    = module.frontend_alb.alb_dns_name
+  alb_target_group_arn            = module.frontend_alb.alb_target_group_arn
+  alb_zone_id                     = module.frontend_alb.alb_zone_id
+  dns_zone_id                     = local.dns_zone_id
+  environment                     = local.environment
+  environment_full_name           = local.environment_full_name_map[local.environment]
+  common_tags                     = local.common_tags
+  region                          = local.region
+  vpc_id                          = module.shared_vpc.vpc_id
+  public_subnets                  = module.shared_vpc.public_subnets
+  private_subnets                 = module.shared_vpc.private_subnets
+  dns_zone_name_trimmed           = local.dns_zone_name_trimmed
+  auth_url                        = module.keycloak.auth_url
+  frontend_app_client_secret_path = module.keycloak.frontend_app_client_secret_path
 }
 
 module "keycloak" {

--- a/root.tf
+++ b/root.tf
@@ -54,7 +54,7 @@ module "frontend" {
   private_subnets       = module.shared_vpc.private_subnets
   dns_zone_name_trimmed = local.dns_zone_name_trimmed
   auth_url              = module.keycloak.auth_url
-  client_secret_path    = module.keycloak.client_secret_path
+  frontend_app_client_secret_path    = module.keycloak.frontend_app_client_secret_path
 }
 
 module "keycloak" {

--- a/root.tf
+++ b/root.tf
@@ -39,22 +39,23 @@ module "consignment_api" {
 }
 
 module "frontend" {
-  app_name              = "frontend"
-  source                = "./modules/transfer-frontend"
-  alb_dns_name          = module.frontend_alb.alb_dns_name
-  alb_target_group_arn  = module.frontend_alb.alb_target_group_arn
-  alb_zone_id           = module.frontend_alb.alb_zone_id
-  dns_zone_id           = local.dns_zone_id
-  environment           = local.environment
-  environment_full_name = local.environment_full_name_map[local.environment]
-  common_tags           = local.common_tags
-  region                = local.region
-  vpc_id                = module.shared_vpc.vpc_id
-  public_subnets        = module.shared_vpc.public_subnets
-  private_subnets       = module.shared_vpc.private_subnets
-  dns_zone_name_trimmed = local.dns_zone_name_trimmed
-  auth_url              = module.keycloak.auth_url
-  client_secret_path    = module.keycloak.client_secret_path
+  app_name                          = "frontend"
+  source                            = "./modules/transfer-frontend"
+  alb_dns_name                      = module.frontend_alb.alb_dns_name
+  alb_target_group_arn              = module.frontend_alb.alb_target_group_arn
+  alb_zone_id                       = module.frontend_alb.alb_zone_id
+  dns_zone_id                       = local.dns_zone_id
+  environment                       = local.environment
+  environment_full_name             = local.environment_full_name_map[local.environment]
+  common_tags                       = local.common_tags
+  region                            = local.region
+  vpc_id                            = module.shared_vpc.vpc_id
+  public_subnets                    = module.shared_vpc.public_subnets
+  private_subnets                   = module.shared_vpc.private_subnets
+  dns_zone_name_trimmed             = local.dns_zone_name_trimmed
+  auth_url                          = module.keycloak.auth_url
+  client_secret_path                = module.keycloak.client_secret_path
+  backend_checks_client_secret_path = module.keycloak.backend_checks_client_secret_path
 }
 
 module "keycloak" {

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "eu-west-2"
+  region  = "eu-west-2"
   version = 2.58
 
   assume_role {


### PR DESCRIPTION
Updating the database through the API with the backend checks data, requires authorisation via a keycloak service account, as backend checks triggerd by lambda, not a user

Keycloak service account authorisation requires additional secret to allow for retrieval of token by client id and client secret: https://www.keycloak.org/docs/latest/server_admin/index.html

Create and expose the backend checks secret to the relevant TDR modules to allow updating of the backend checks data via lambda