### PR TITLE
Ignore changes to Keycloak client secrets

### DIFF
--- a/modules/keycloak/ssm.tf
+++ b/modules/keycloak/ssm.tf
@@ -40,10 +40,18 @@ resource "aws_ssm_parameter" "keycloak_client_secret" {
   name  = "/${var.environment}/keycloak/client/secret"
   type  = "SecureString"
   value = random_uuid.client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
   name  = "/${var.environment}/keycloak/backend_checks_client/secret"
   type  = "SecureString"
   value = random_uuid.backend_checks_client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }


### PR DESCRIPTION
Prevent Terraform from regenerating Keycloak client secrets, because changing them breaks the integration between the client apps and the Keycloak server.

We will need to revisit this to find a way to safely refresh a secret without causing downtime.