### PR TITLE
Allow uploads to the intg dirty bucket from the local dev environment

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -104,8 +104,7 @@ module "upload_file_dirty_s3" {
   project           = var.project
   function          = "upload-files-dirty"
   common_tags       = local.common_tags
-  // TODO: Update to include localhost in integration
-  cors_urls         = [module.frontend.frontend_url]
+  cors_urls         = local.upload_cors_urls
   version_lifecycle = true
   sns_topic_arn     = module.dirty_upload_sns_topic.sns_arn
   sns_notification  = true

--- a/root.tf
+++ b/root.tf
@@ -104,8 +104,8 @@ module "upload_file_dirty_s3" {
   project           = var.project
   function          = "upload-files-dirty"
   common_tags       = local.common_tags
-  cors              = true
-  frontend_url      = module.frontend.frontend_url
+  // TODO: Update to include localhost in integration
+  cors_urls         = [module.frontend.frontend_url]
   version_lifecycle = true
   sns_topic_arn     = module.dirty_upload_sns_topic.sns_arn
   sns_notification  = true

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -26,4 +26,8 @@ locals {
   dns_zone_name_trimmed = trimsuffix(data.aws_route53_zone.tdr_dns_zone.name, ".")
 
   environment_domain = local.environment == "prod" ? "${var.project}.${var.domain}" : "${var.project}-${local.environment_full_name}.${var.domain}"
+
+  local_dev_frontend_url = "http://localhost:9000"
+
+  upload_cors_urls = local.environment == "intg" ? [module.frontend.frontend_url, local.local_dev_frontend_url] : [module.frontend.frontend_url]
 }


### PR DESCRIPTION
Enable cross-origin requests from the local dev host (localhost:9000) in the integration environment.

This will make it possible to do local development against the integration backend.

This change depends on https://github.com/nationalarchives/tdr-terraform-modules/pull/32