### PR TITLE
Fix SSM parameter issue in mgmt

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -280,10 +280,11 @@ module "api_update_antivirus_queue" {
 
 
 module "api_update_antivirus_lambda" {
-  source               = "./tdr-terraform-modules/lambda"
-  project              = var.project
-  common_tags          = local.common_tags
-  lambda_api_update_av = true
-  auth_url             = module.keycloak.auth_url
-  api_url              = module.consignment_api.api_url
+  source                                = "./tdr-terraform-modules/lambda"
+  project                               = var.project
+  common_tags                           = local.common_tags
+  lambda_api_update_av                  = true
+  auth_url                              = module.keycloak.auth_url
+  api_url                               = module.consignment_api.api_url
+  keycloak_backend_checks_client_secret = data.aws_ssm_parameter.keycloak_backend_checks_client_secret.value
 }

--- a/root.tf
+++ b/root.tf
@@ -278,7 +278,6 @@ module "api_update_antivirus_queue" {
   sqs_policy  = "api_update_antivirus"
 }
 
-
 module "api_update_antivirus_lambda" {
   source                                = "./tdr-terraform-modules/lambda"
   project                               = var.project

--- a/root_data.tf
+++ b/root_data.tf
@@ -9,3 +9,7 @@ data "aws_ssm_parameter" "trusted_ips" {
 data "aws_route53_zone" "tdr_dns_zone" {
   name = local.environment == "prod" ? "${var.project}.${var.domain}" : "${var.project}-${local.environment_full_name}.${var.domain}"
 }
+
+data "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
+  name = "/${local.environment}/keycloak/backend_checks_client/secret"
+}


### PR DESCRIPTION
Allows tdr-terraform-modules to be used in environments such as mgmt where this SSM parameter doesn't exist