### PR TITLE
Add cloudwatch log group and permissions.

### DIFF
--- a/modules/database-migrations/lambda.tf
+++ b/modules/database-migrations/lambda.tf
@@ -31,6 +31,14 @@ data "aws_iam_policy_document" "lambda_migration_document" {
   statement {
     effect = "Allow"
     actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [aws_cloudwatch_log_group.db_migration_log_group.arn]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
       "ec2:DeleteNetworkInterface",
       "ec2:DescribeInstances",
       "ec2:CreateNetworkInterface",
@@ -90,4 +98,9 @@ resource "aws_security_group" "db_migration" {
     var.common_tags,
     map("Name", "db-migration-security-group-${var.environment}")
   )
+}
+
+resource "aws_cloudwatch_log_group" "db_migration_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.database_migration_function.function_name}"
+  retention_in_days = 30
 }


### PR DESCRIPTION
The execution role didn’t have permission to view the cloudwatch logs.
I’ve added the permission in but it still complains that you don’t have the permission
but if you run the migration lambda, the logs are available in cloudwatch
so this time, the message is wrong.

This is the message we get for all our lambdas and they log to cloudwatch
fine so this is just something wrong in the AWS console.
I suspect it needs * in the resources in the policy or we need to use
the AWS managed policy or something but we're not going to do either of
those things so we can safely ignore it.