### PR TITLE
Replace space with percent encoding

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                             tdr.postToDaTdrSlackChannel(colour: "good",
                                                         message: "Terraform plan complete for ${params.STAGE} TDR environment." +
                                                                  "View here for plan: https://jenkins.tdr-management.nationalarchives.gov.uk/job/" +
-                                                                 "${JOB_NAME.replaceAll(" ", "%20")}/${BUILD_NUMBER}/console"
+                                                                 "${JOB_NAME.replaceAll(' ', '%20')}/${BUILD_NUMBER}/console"
                             )
                         }
                     }
@@ -55,7 +55,8 @@ pipeline {
                         script {
                             tdr.postToDaTdrSlackChannel(colour: "good",
                                                         message: "Do you approve Terraform deployment for ${params.STAGE} TDR environment?" +
-                                                                 "https://jenkins.tdr-management.nationalarchives.gov.uk/job/${JOB_NAME.replaceAll(" ", "%20")}/${BUILD_NUMBER}/input/"
+                                                                 "https://jenkins.tdr-management.nationalarchives.gov.uk/job/" +
+                                                                 "${JOB_NAME.replaceAll(' ', '%20')}/${BUILD_NUMBER}/input/"
                             )
                         }
                         input "Do you approve deployment to ${params.STAGE}?"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,8 @@ pipeline {
                         script {
                             tdr.postToDaTdrSlackChannel(colour: "good",
                                                         message: "Terraform plan complete for ${params.STAGE} TDR environment." +
-                                                                 "View here for plan: https://jenkins.tdr-management.nationalarchives.gov.uk/job/${JOB_NAME}/${BUILD_NUMBER}/console"
+                                                                 "View here for plan: https://jenkins.tdr-management.nationalarchives.gov.uk/job/" +
+                                                                 "${JOB_NAME.replaceAll(" ", "%20")}/${BUILD_NUMBER}/console"
                             )
                         }
                     }
@@ -54,7 +55,7 @@ pipeline {
                         script {
                             tdr.postToDaTdrSlackChannel(colour: "good",
                                                         message: "Do you approve Terraform deployment for ${params.STAGE} TDR environment?" +
-                                                                 "https://jenkins.tdr-management.nationalarchives.gov.uk/job/${JOB_NAME}/${BUILD_NUMBER}/input/"
+                                                                 "https://jenkins.tdr-management.nationalarchives.gov.uk/job/${JOB_NAME.replaceAll(" ", "%20")}/${BUILD_NUMBER}/input/"
                             )
                         }
                         input "Do you approve deployment to ${params.STAGE}?"


### PR DESCRIPTION
Whenever Jenkins posts a Terraform message in Slack, the link in broken due to the spaces in the job name. This PR replaces spaces with the percent encoding