### PR TITLE
Make environment name available as environment variable

### DIFF
--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -35,6 +35,10 @@
     ],
     "environment": [
       {
+        "name" : "ENVIRONMENT",
+        "value" : "${app_environment}"
+      },
+      {
         "name" : "FRONTEND_URL",
         "value" : "${frontend_url}"
       },

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -35,8 +35,8 @@
     ],
     "environment": [
       {
-        "name" : "ENVIRONMENT",
-        "value" : "${app_environment}"
+        "name" : "KEYCLOAK_CONFIGURATION_PROPERTIES",
+        "value" : "${app_environment}_properties.json"
       },
       {
         "name" : "FRONTEND_URL",


### PR DESCRIPTION
Each TDR environment has specific Keycloak configuration for some properties which differ across the TDR environments

Require the TDR environment to be available as environment variable to know which environment Keycloak docker image is being built in to apply the specific Keycloak configuration