### PR TITLE
Upgrade the AWS provider to 2.69

### DIFF
--- a/root_provider.tf
+++ b/root_provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "eu-west-2"
-  version = 2.58
+  version = 2.69
 
   assume_role {
     role_arn     = local.assume_role


### PR DESCRIPTION
This gives us access to new EFS features, which we're planning to use in the file format checks.