### PR TITLE
New Keycloak realm client secret

### DIFF
--- a/modules/keycloak/ecs.tf
+++ b/modules/keycloak/ecs.tf
@@ -25,6 +25,7 @@ data "template_file" "app" {
     admin_password_path               = aws_ssm_parameter.keycloak_admin_password.name
     client_secret_path                = aws_ssm_parameter.keycloak_client_secret.name
     backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
+    realm_admin_client_secret_path    = aws_ssm_parameter.keycloak_realm_admin_client_secret.name
     frontend_url                      = var.frontend_url
 
   }

--- a/modules/keycloak/ssm.tf
+++ b/modules/keycloak/ssm.tf
@@ -55,3 +55,13 @@ resource "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "keycloak_realm_admin_client_secret" {
+  name  = "/${var.environment}/keycloak/realm_admin_client/secret"
+  type  = "SecureString"
+  value = random_uuid.backend_checks_client_secret.result
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -31,6 +31,10 @@
       {
         "valueFrom": "${backend_checks_client_secret_path}",
         "name": "BACKEND_CHECKS_CLIENT_SECRET"
+      },
+      {
+        "valueFrom": "${realm_admin_client_secret_path}",
+        "name": "REALM_ADMIN_CLIENT_SECRET"
       }
     ],
     "environment": [


### PR DESCRIPTION
Additional Keycloak client added to TDR realm to allow for updating of realm using APIs

To make API calls using client credential to obtain access token. Therefore need a new client secret for the client.