### PR TITLE
Add keycloak config properties ssm parameter

### DIFF
--- a/modules/keycloak/ecs.tf
+++ b/modules/keycloak/ecs.tf
@@ -27,7 +27,7 @@ data "template_file" "app" {
     backend_checks_client_secret_path = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
     realm_admin_client_secret_path    = aws_ssm_parameter.keycloak_realm_admin_client_secret.name
     frontend_url                      = var.frontend_url
-
+    configuration_properties_path     = aws_ssm_parameter.keycloak_configuration_properties.name
   }
 }
 

--- a/modules/keycloak/ssm.tf
+++ b/modules/keycloak/ssm.tf
@@ -65,3 +65,9 @@ resource "aws_ssm_parameter" "keycloak_realm_admin_client_secret" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "keycloak_configuration_properties" {
+  name  = "/${var.environment}/keycloak/configuration_properties"
+  type  = "String"
+  value = "${var.environment}_properties.json"
+}

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -39,8 +39,8 @@
     ],
     "environment": [
       {
-        "name" : "KEYCLOAK_CONFIGURATION_PROPERTIES",
-        "value" : "${app_environment}_properties.json"
+        "valueFrom": "${configuration_properties_path}",
+        "name" : "KEYCLOAK_CONFIGURATION_PROPERTIES"
       },
       {
         "name" : "FRONTEND_URL",


### PR DESCRIPTION
Both Auth Server docker build and the Jenkins update environments require the keycloak configuration properties.

For both enviornment to access this value it should be set in the ssm parameters so it comes from a single source for both environments