### PR TITLE
Move keycloak to postgres

### DIFF
--- a/modules/keycloak/database.tf
+++ b/modules/keycloak/database.tf
@@ -27,7 +27,7 @@ resource "aws_rds_cluster" "keycloak_database" {
   engine_version                  = "11.6"
   availability_zones              = var.database_availability_zones
   database_name                   = var.app_name
-  master_username                 = "api_admin"
+  master_username                 = "keycloak_admin"
   master_password                 = random_password.password.result
   final_snapshot_identifier       = "keycloak-db-final-snapshot-${random_string.snapshot_prefix.result}-${var.environment}"
   storage_encrypted               = true
@@ -36,10 +36,10 @@ resource "aws_rds_cluster" "keycloak_database" {
   db_subnet_group_name            = aws_db_subnet_group.user_subnet_group.name
   enabled_cloudwatch_logs_exports = ["postgresql"]
   tags = merge(
-  var.common_tags,
-  map(
-  "Name", "content-db-cluster-${var.environment}"
-  )
+    var.common_tags,
+    map(
+      "Name", "keycloak-db-cluster-${var.environment}"
+    )
   )
 
   lifecycle {

--- a/modules/keycloak/database.tf
+++ b/modules/keycloak/database.tf
@@ -22,23 +22,24 @@ resource "random_string" "snapshot_prefix" {
 }
 
 resource "aws_rds_cluster" "keycloak_database" {
-  cluster_identifier_prefix = "keycloak-db-${var.environment}"
-  engine                    = "aurora"
-  engine_mode               = "serverless"
-  engine_version            = "5.6.10a"
-  availability_zones        = var.database_availability_zones
-  database_name             = "keycloak"
-  master_username           = "keycloak_admin"
-  master_password           = random_password.password.result
-  final_snapshot_identifier = "user-db-final-snapshot-${random_string.snapshot_prefix.result}-${var.environment}"
-  vpc_security_group_ids    = aws_security_group.database.*.id
-  db_subnet_group_name      = aws_db_subnet_group.user_subnet_group.name
-
+  cluster_identifier_prefix       = "keycloak-db-postgres-${var.environment}"
+  engine                          = "aurora-postgresql"
+  engine_version                  = "11.6"
+  availability_zones              = var.database_availability_zones
+  database_name                   = var.app_name
+  master_username                 = "api_admin"
+  master_password                 = random_password.password.result
+  final_snapshot_identifier       = "keycloak-db-final-snapshot-${random_string.snapshot_prefix.result}-${var.environment}"
+  storage_encrypted               = true
+  kms_key_id                      = var.kms_key_id
+  vpc_security_group_ids          = aws_security_group.database.*.id
+  db_subnet_group_name            = aws_db_subnet_group.user_subnet_group.name
+  enabled_cloudwatch_logs_exports = ["postgresql"]
   tags = merge(
-    var.common_tags,
-    map(
-      "Name", "content-db-cluster-${var.environment}"
-    )
+  var.common_tags,
+  map(
+  "Name", "content-db-cluster-${var.environment}"
+  )
   )
 
   lifecycle {
@@ -51,3 +52,12 @@ resource "aws_rds_cluster" "keycloak_database" {
   }
 }
 
+resource "aws_rds_cluster_instance" "user_database_instance" {
+  count                = 1
+  identifier_prefix    = "content-db-postgres-instance-${var.environment}"
+  cluster_identifier   = aws_rds_cluster.keycloak_database.id
+  engine               = "aurora-postgresql"
+  engine_version       = "11.6"
+  instance_class       = "db.t3.medium"
+  db_subnet_group_name = aws_db_subnet_group.user_subnet_group.name
+}

--- a/modules/keycloak/security.tf
+++ b/modules/keycloak/security.tf
@@ -56,8 +56,8 @@ resource "aws_security_group" "database" {
 
   ingress {
     protocol        = "tcp"
-    from_port       = 3306
-    to_port         = 3306
+    from_port       = 5432
+    to_port         = 5432
     security_groups = [aws_security_group.ecs_tasks.id]
   }
 

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -48,7 +48,7 @@
       },
       {
         "name" : "DB_VENDOR",
-        "value" : "mysql"
+        "value" : "postgres"
       },
       {
         "name" : "KEYCLOAK_IMPORT",

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -29,4 +29,6 @@ variable "ip_whitelist" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "kms_key_id" {}
+variable "kms_key_id" {
+  description = "KMS ID for the database encryption key"
+}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -28,3 +28,5 @@ variable "ip_whitelist" {
   description = "IP addresses allowed to access"
   default     = ["0.0.0.0/0"]
 }
+
+variable "kms_key_id" {}

--- a/root.tf
+++ b/root.tf
@@ -78,6 +78,7 @@ module "keycloak" {
   az_count                    = 2
   region                      = local.region
   frontend_url                = module.frontend.frontend_url
+  kms_key_id                  = module.encryption_key.kms_key_arn
 }
 
 module "alb_logs_s3" {


### PR DESCRIPTION
The version of mysql on aurora serverless was too old to work with the
latest version of keycloak properly.
We were also getting a lot of connection errors from keycloak which is
unrelated to the upgrade but still isn't great.
So I've moved keycloak to use standard postgres RDS which is the same DB
the consignment api uses so we're at least consistent now.