### PR TITLE
Rename EFS file system

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -324,45 +324,47 @@ module "api_update_lambda" {
 }
 
 module "file_format_lambda" {
-  source                       = "./tdr-terraform-modules/lambda"
-  project                      = var.project
-  common_tags                  = local.common_tags
-  lambda_file_format           = true
-  file_system_id               = module.file_format_efs.file_system_id
-  file_format_efs_access_point = module.file_format_efs.access_point
-  vpc_id                       = module.shared_vpc.vpc_id
-  use_efs                      = true
+  source                                 = "./tdr-terraform-modules/lambda"
+  project                                = var.project
+  common_tags                            = local.common_tags
+  lambda_file_format                     = true
+  file_system_id                         = module.backend_checks_efs.file_system_id
+  backend_checks_efs_access_point        = module.backend_checks_efs.access_point
+  vpc_id                                 = module.shared_vpc.vpc_id
+  use_efs                                = true
+  backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
 }
 
 module "download_files_lambda" {
-  source                       = "./tdr-terraform-modules/lambda"
-  common_tags                  = local.common_tags
-  project                      = var.project
-  lambda_download_files        = true
-  s3_sns_topic                 = module.dirty_upload_sns_topic.sns_arn
-  file_system_id               = module.file_format_efs.file_system_id
-  file_format_efs_access_point = module.file_format_efs.access_point
-  vpc_id                       = module.shared_vpc.vpc_id
-  use_efs                      = true
-  auth_url                     = module.keycloak.auth_url
-  api_url                      = module.consignment_api.api_url
+  source                                 = "./tdr-terraform-modules/lambda"
+  common_tags                            = local.common_tags
+  project                                = var.project
+  lambda_download_files                  = true
+  s3_sns_topic                           = module.dirty_upload_sns_topic.sns_arn
+  file_system_id                         = module.backend_checks_efs.file_system_id
+  backend_checks_efs_access_point        = module.backend_checks_efs.access_point
+  vpc_id                                 = module.shared_vpc.vpc_id
+  use_efs                                = true
+  auth_url                               = module.keycloak.auth_url
+  api_url                                = module.consignment_api.api_url
+  backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
 }
 
-module "file_format_efs" {
+module "backend_checks_efs" {
   source                       = "./tdr-terraform-modules/efs"
   common_tags                  = local.common_tags
-  function                     = "file-format-efs"
+  function                     = "backend-checks-efs"
   project                      = var.project
-  access_point_path            = "/fileformat"
-  policy                       = "file_format_access_policy"
+  access_point_path            = "/backend-checks"
+  policy                       = "backend_checks_access_policy"
   mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id])
 }
 
 module "file_format_build_task" {
   source            = "./tdr-terraform-modules/ecs"
   common_tags       = local.common_tags
-  file_system_id    = module.file_format_efs.file_system_id
-  access_point      = module.file_format_efs.access_point
+  file_system_id    = module.backend_checks_efs.file_system_id
+  access_point      = module.backend_checks_efs.access_point
   file_format_build = true
   project           = var.project
 }


### PR DESCRIPTION
Requires: https://github.com/nationalarchives/tdr-terraform-modules/pull/50

EFS file system to be used by all backend checks

Rename resources to reflect use by all backend checks not just file format check