### PR TITLE
Add alb network interface private IPs

### DIFF
--- a/modules/shared-vpc/root.tf
+++ b/modules/shared-vpc/root.tf
@@ -30,7 +30,8 @@ resource "aws_subnet" "private" {
 }
 
 
-
+# The frontend uses the network interface IPs which come from the range in this subnet.
+# If any changes are made to this subnets IP range, the front end will need to be re-deployed.
 # Create var.az_count public subnets, each in a different AZ
 resource "aws_subnet" "public" {
   count                   = var.az_count

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -10,6 +10,8 @@ resource "aws_ecs_cluster" "frontend_ecs" {
   )
 }
 
+data "aws_caller_identity" "current" {}
+
 data "template_file" "app" {
   template = file("modules/transfer-frontend/templates/frontend.json.tpl")
 
@@ -21,6 +23,30 @@ data "template_file" "app" {
     client_secret_path = var.client_secret_path
     identity_pool_id   = aws_cognito_identity_pool.tdr_frontend_identity_pool.id
     export_api_url     = var.export_api_url
+    alb_ip_a           = data.aws_network_interface.alb_network_interface_a.private_ip
+    alb_ip_b           = data.aws_network_interface.alb_network_interface_b.private_ip
+  }
+}
+
+data aws_network_interface alb_network_interface_a {
+  filter {
+    name   = "description"
+    values = ["ELB ${replace(var.alb_id, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/", "")}"]
+  }
+  filter {
+    name   = "availability-zone"
+    values = ["${var.region}a"]
+  }
+}
+
+data aws_network_interface alb_network_interface_b {
+  filter {
+    name   = "description"
+    values = ["ELB ${replace(var.alb_id, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/", "")}"]
+  }
+  filter {
+    name   = "availability-zone"
+    values = ["${var.region}b"]
   }
 }
 

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -29,6 +29,14 @@
       {
         "name": "EXPORT_API_URL",
         "value": "${export_api_url}"
+      },
+      {
+        "name": "ALB_IP_A",
+        "value": "${alb_ip_a}"
+      },
+      {
+        "name": "ALB_IP_B",
+        "value": "${alb_ip_b}"
       }
     ],
     "networkMode": "awsvpc",

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -35,3 +35,5 @@ variable "ip_whitelist" {
 
 variable "export_api_url" {}
 
+variable "alb_id" {}
+

--- a/root.tf
+++ b/root.tf
@@ -184,6 +184,8 @@ module "frontend_certificate" {
   common_tags = local.common_tags
 }
 
+# The frontend uses the network interface IPs which are created for this load balancer.
+# If any changes are made to this load balancer which will cause a redeploy then the front end will also need to be deployed.
 module "frontend_alb" {
   source                = "./tdr-terraform-modules/alb"
   project               = var.project

--- a/root.tf
+++ b/root.tf
@@ -62,6 +62,7 @@ module "frontend" {
   auth_url              = module.keycloak.auth_url
   client_secret_path    = module.keycloak.client_secret_path
   export_api_url        = module.export_api.api_url
+  alb_id                = module.frontend_alb.alb_id
 }
 
 module "keycloak" {


### PR DESCRIPTION
We need to add the trusted IP addresses to the play app so that the
https forwarding from the load balancer works properly.
The IPs that the load balancer uses are the private IPs of the network
interfaces. These are created by AWS when you create the load balancer
and can't be specified in terraform directly so I'm using the network
interface data to get the interfaces for both availability zones and
passing them to the play app via environment variables.
