### PR TITLE
Add an awslogs-datetime-format

### DIFF
--- a/modules/consignment-api/templates/consignment-api.json.tpl
+++ b/modules/consignment-api/templates/consignment-api.json.tpl
@@ -41,7 +41,8 @@
       "options": {
         "awslogs-group": "/ecs/consignment-api-${app_environment}",
         "awslogs-region": "${aws_region}",
-        "awslogs-stream-prefix": "ecs"
+        "awslogs-stream-prefix": "ecs",
+        "awslogs-datetime-format": "%H:%M:%S.%L"
       }
     },
     "portMappings": [

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -65,7 +65,8 @@
       "options": {
         "awslogs-group": "/ecs/keycloak-${app_environment}",
         "awslogs-region": "${aws_region}",
-        "awslogs-stream-prefix": "ecs"
+        "awslogs-stream-prefix": "ecs",
+        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S,%L"
       }
     },
     "portMappings": [

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -49,7 +49,8 @@
       "options": {
         "awslogs-group": "/ecs/frontend-${app_environment}",
         "awslogs-region": "${aws_region}",
-        "awslogs-stream-prefix": "ecs"
+        "awslogs-stream-prefix": "ecs",
+        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S,%L"
       }
     },
     "portMappings": [


### PR DESCRIPTION
The problem is that when a stack trace is logged, cloudwatch puts each trace line in its own event which is hard to read. This tells cloudwatch the format of the date to look for and will put any following lines in the same event until it gets to another date.
