### PR TITLE
Add NAT public IP to WAF.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -222,7 +222,7 @@ module "waf" {
   environment       = local.environment
   common_tags       = local.common_tags
   alb_target_groups = [module.keycloak_alb.alb_arn, module.consignment_api_alb.alb_arn, module.frontend_alb.alb_arn]
-  trusted_ips       = split(",", data.aws_ssm_parameter.trusted_ips.value)
+  trusted_ips       = concat(split(",", data.aws_ssm_parameter.trusted_ips.value), list("${data.aws_nat_gateway.main_one.public_ip}/32", "${data.aws_nat_gateway.main_zero.public_ip}/32"))
   geo_match         = split(",", var.geo_match)
   restricted_uri    = "auth/admin"
 }

--- a/root_data.tf
+++ b/root_data.tf
@@ -13,3 +13,11 @@ data "aws_route53_zone" "tdr_dns_zone" {
 data "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
   name = "/${local.environment}/keycloak/backend_checks_client/secret"
 }
+
+data "aws_nat_gateway" "main_zero" {
+  tags = map("Name", "nat-gateway-0-tdr-${local.environment}")
+}
+
+data "aws_nat_gateway" "main_one" {
+  tags = map("Name", "nat-gateway-1-tdr-${local.environment}")
+}


### PR DESCRIPTION
The export task needs to talk to the keycloak admin url but that is hidden behind the WAF which has an IP whitelist. We need to add the NAT public IPs which is what the ECS tasks use to get to the internet, to the WAF.
