### PR TITLE
Create production

### DIFF
--- a/modules/database-migrations/lambda.tf
+++ b/modules/database-migrations/lambda.tf
@@ -80,6 +80,7 @@ resource "aws_lambda_function" "database_migration_function" {
       STAGE       = var.environment
     }
   }
+  depends_on = [aws_iam_role_policy_attachment.lambda_role_attach_migration_policy]
 }
 
 resource "aws_security_group" "db_migration" {
@@ -101,6 +102,6 @@ resource "aws_security_group" "db_migration" {
 }
 
 resource "aws_cloudwatch_log_group" "db_migration_log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.database_migration_function.function_name}"
+  name              = "/aws/lambda/tdr-database-migrations-${var.environment}"
   retention_in_days = 30
 }

--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -21,3 +21,7 @@ output "client_secret_path" {
 output "backend_checks_client_secret_path" {
   value = aws_ssm_parameter.keycloak_backend_checks_client_secret.name
 }
+
+output "backend_checks_client_secret" {
+  value = aws_ssm_parameter.keycloak_backend_checks_client_secret.value
+}

--- a/modules/shared-vpc/flowlogs.tf
+++ b/modules/shared-vpc/flowlogs.tf
@@ -47,7 +47,6 @@ resource "aws_iam_policy" "tdr_flowlog_policy" {
 data "aws_iam_policy_document" "tdr_flowlog_policy" {
   statement {
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",

--- a/modules/shared-vpc/outputs.tf
+++ b/modules/shared-vpc/outputs.tf
@@ -13,3 +13,15 @@ output "public_subnet_ranges" {
 output "private_subnets" {
   value = aws_subnet.private.*.id
 }
+
+output "nat_gateway_ids" {
+  value = aws_nat_gateway.gw.*.id
+}
+
+output "vpc_cidr_block" {
+  value = aws_vpc.main.cidr_block
+}
+
+output "nat_gateway_public_ips" {
+  value = aws_nat_gateway.gw.*.public_ip
+}

--- a/root.tf
+++ b/root.tf
@@ -246,6 +246,8 @@ module "antivirus_lambda" {
   use_efs                                = true
   vpc_id                                 = module.shared_vpc.vpc_id
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
+  mount_target_zero = module.backend_checks_efs.mount_target_zero
+  mount_target_one = module.backend_checks_efs.mount_target_one
 }
 
 module "checksum_lambda" {
@@ -259,6 +261,8 @@ module "checksum_lambda" {
   use_efs                                = true
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
+  mount_target_zero = module.backend_checks_efs.mount_target_zero
+  mount_target_one = module.backend_checks_efs.mount_target_one
 }
 
 module "dirty_upload_sns_topic" {
@@ -350,6 +354,8 @@ module "file_format_lambda" {
   use_efs                                = true
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
+  mount_target_zero = module.backend_checks_efs.mount_target_zero
+  mount_target_one = module.backend_checks_efs.mount_target_one
 }
 
 module "download_files_lambda" {

--- a/root.tf
+++ b/root.tf
@@ -320,7 +320,9 @@ module "file_format_sqs_queue" {
   function                 = "file-format"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout       = 900
+  // Terraform will fail if the visibility timeout is shorter than the lambda timeout.
+  // The timeout for the file format lambda is set to 900 seconds, more than the other backend check lambdas because the file format lambda is slower than the others
+  visibility_timeout = 900
 }
 
 module "api_update_queue" {

--- a/root.tf
+++ b/root.tf
@@ -246,8 +246,8 @@ module "antivirus_lambda" {
   use_efs                                = true
   vpc_id                                 = module.shared_vpc.vpc_id
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
-  mount_target_zero = module.backend_checks_efs.mount_target_zero
-  mount_target_one = module.backend_checks_efs.mount_target_one
+  mount_target_zero                      = module.backend_checks_efs.mount_target_zero
+  mount_target_one                       = module.backend_checks_efs.mount_target_one
 }
 
 module "checksum_lambda" {
@@ -261,8 +261,8 @@ module "checksum_lambda" {
   use_efs                                = true
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
-  mount_target_zero = module.backend_checks_efs.mount_target_zero
-  mount_target_one = module.backend_checks_efs.mount_target_one
+  mount_target_zero                      = module.backend_checks_efs.mount_target_zero
+  mount_target_one                       = module.backend_checks_efs.mount_target_one
 }
 
 module "dirty_upload_sns_topic" {
@@ -310,7 +310,7 @@ module "checksum_sqs_queue" {
   sqs_policy               = "sns_topic"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout = 180
+  visibility_timeout       = 180
 }
 
 module "file_format_sqs_queue" {
@@ -354,8 +354,8 @@ module "file_format_lambda" {
   use_efs                                = true
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
-  mount_target_zero = module.backend_checks_efs.mount_target_zero
-  mount_target_one = module.backend_checks_efs.mount_target_one
+  mount_target_zero                      = module.backend_checks_efs.mount_target_zero
+  mount_target_one                       = module.backend_checks_efs.mount_target_one
 }
 
 module "download_files_lambda" {
@@ -372,7 +372,7 @@ module "download_files_lambda" {
   api_url                                = module.consignment_api.api_url
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
-  backend_checks_client_secret = module.keycloak.backend_checks_client_secret
+  backend_checks_client_secret           = module.keycloak.backend_checks_client_secret
 }
 
 module "backend_checks_efs" {
@@ -383,9 +383,9 @@ module "backend_checks_efs" {
   access_point_path            = "/backend-checks"
   policy                       = "backend_checks_access_policy"
   mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id, module.antivirus_lambda.antivirus_lambda_sg_id, module.checksum_lambda.checksum_lambda_sg_id])
-  nat_gateway_ids = module.shared_vpc.nat_gateway_ids
-  vpc_cidr_block = module.shared_vpc.vpc_cidr_block
-  vpc_id = module.shared_vpc.vpc_id
+  nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
+  vpc_cidr_block               = module.shared_vpc.vpc_cidr_block
+  vpc_id                       = module.shared_vpc.vpc_id
 }
 
 module "file_format_build_task" {
@@ -395,7 +395,7 @@ module "file_format_build_task" {
   access_point      = module.backend_checks_efs.access_point
   file_format_build = true
   project           = var.project
-  vpc_id = module.shared_vpc.vpc_id
+  vpc_id            = module.shared_vpc.vpc_id
 }
 
 module "export_api" {
@@ -427,9 +427,9 @@ module "export_efs" {
   policy                       = "export_access_policy"
   mount_target_security_groups = flatten([module.export_task.consignment_export_sg_id])
   netnum_offset                = 6
-  nat_gateway_ids = module.shared_vpc.nat_gateway_ids
-  vpc_cidr_block = module.shared_vpc.vpc_cidr_block
-  vpc_id = module.shared_vpc.vpc_id
+  nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
+  vpc_cidr_block               = module.shared_vpc.vpc_cidr_block
+  vpc_id                       = module.shared_vpc.vpc_id
 }
 
 module "export_task" {
@@ -444,7 +444,7 @@ module "export_task" {
   output_bucket              = module.export_bucket.s3_bucket_name
   api_url                    = module.consignment_api.api_url
   auth_url                   = module.keycloak.auth_url
-  vpc_id = module.shared_vpc.vpc_id
+  vpc_id                     = module.shared_vpc.vpc_id
 }
 
 module "export_step_function" {

--- a/root.tf
+++ b/root.tf
@@ -439,7 +439,7 @@ module "export_task" {
   consignment_export         = true
   file_system_id             = module.export_efs.file_system_id
   access_point               = module.export_efs.access_point
-  backend_client_secret_path = module.keycloak.backend_checks_client_secret
+  backend_client_secret_path = module.keycloak.backend_checks_client_secret_path
   clean_bucket               = module.upload_bucket.s3_bucket_name
   output_bucket              = module.export_bucket.s3_bucket_name
   api_url                    = module.consignment_api.api_url

--- a/root.tf
+++ b/root.tf
@@ -223,7 +223,7 @@ module "waf" {
   environment       = local.environment
   common_tags       = local.common_tags
   alb_target_groups = [module.keycloak_alb.alb_arn, module.consignment_api_alb.alb_arn, module.frontend_alb.alb_arn]
-  trusted_ips       = concat(split(",", data.aws_ssm_parameter.trusted_ips.value), list("${data.aws_nat_gateway.main_one.public_ip}/32", "${data.aws_nat_gateway.main_zero.public_ip}/32"))
+  trusted_ips       = concat(split(",", data.aws_ssm_parameter.trusted_ips.value), list("${module.shared_vpc.nat_gateway_public_ips[0]}/32", "${module.shared_vpc.nat_gateway_public_ips[1]}/32"))
   geo_match         = split(",", var.geo_match)
   restricted_uri    = "auth/admin"
 }
@@ -306,6 +306,7 @@ module "checksum_sqs_queue" {
   sqs_policy               = "sns_topic"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
+  visibility_timeout = 180
 }
 
 module "file_format_sqs_queue" {
@@ -315,7 +316,7 @@ module "file_format_sqs_queue" {
   function                 = "file-format"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout       = 180
+  visibility_timeout       = 900
 }
 
 module "api_update_queue" {
@@ -335,7 +336,7 @@ module "api_update_lambda" {
   lambda_api_update                     = true
   auth_url                              = module.keycloak.auth_url
   api_url                               = module.consignment_api.api_url
-  keycloak_backend_checks_client_secret = data.aws_ssm_parameter.keycloak_backend_checks_client_secret.value
+  keycloak_backend_checks_client_secret = module.keycloak.backend_checks_client_secret
 }
 
 module "file_format_lambda" {
@@ -365,6 +366,7 @@ module "download_files_lambda" {
   api_url                                = module.consignment_api.api_url
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
+  backend_checks_client_secret = module.keycloak.backend_checks_client_secret
 }
 
 module "backend_checks_efs" {
@@ -375,6 +377,9 @@ module "backend_checks_efs" {
   access_point_path            = "/backend-checks"
   policy                       = "backend_checks_access_policy"
   mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id, module.antivirus_lambda.antivirus_lambda_sg_id, module.checksum_lambda.checksum_lambda_sg_id])
+  nat_gateway_ids = module.shared_vpc.nat_gateway_ids
+  vpc_cidr_block = module.shared_vpc.vpc_cidr_block
+  vpc_id = module.shared_vpc.vpc_id
 }
 
 module "file_format_build_task" {
@@ -384,6 +389,7 @@ module "file_format_build_task" {
   access_point      = module.backend_checks_efs.access_point
   file_format_build = true
   project           = var.project
+  vpc_id = module.shared_vpc.vpc_id
 }
 
 module "export_api" {
@@ -415,6 +421,9 @@ module "export_efs" {
   policy                       = "export_access_policy"
   mount_target_security_groups = flatten([module.export_task.consignment_export_sg_id])
   netnum_offset                = 6
+  nat_gateway_ids = module.shared_vpc.nat_gateway_ids
+  vpc_cidr_block = module.shared_vpc.vpc_cidr_block
+  vpc_id = module.shared_vpc.vpc_id
 }
 
 module "export_task" {
@@ -424,11 +433,12 @@ module "export_task" {
   consignment_export         = true
   file_system_id             = module.export_efs.file_system_id
   access_point               = module.export_efs.access_point
-  backend_client_secret_path = data.aws_ssm_parameter.keycloak_backend_checks_client_secret.name
+  backend_client_secret_path = module.keycloak.backend_checks_client_secret
   clean_bucket               = module.upload_bucket.s3_bucket_name
   output_bucket              = module.export_bucket.s3_bucket_name
   api_url                    = module.consignment_api.api_url
   auth_url                   = module.keycloak.auth_url
+  vpc_id = module.shared_vpc.vpc_id
 }
 
 module "export_step_function" {

--- a/root_data.tf
+++ b/root_data.tf
@@ -9,15 +9,3 @@ data "aws_ssm_parameter" "trusted_ips" {
 data "aws_route53_zone" "tdr_dns_zone" {
   name = local.environment == "prod" ? "${var.project}.${var.domain}" : "${var.project}-${local.environment_full_name}.${var.domain}"
 }
-
-data "aws_ssm_parameter" "keycloak_backend_checks_client_secret" {
-  name = "/${local.environment}/keycloak/backend_checks_client/secret"
-}
-
-data "aws_nat_gateway" "main_zero" {
-  tags = map("Name", "nat-gateway-0-tdr-${local.environment}")
-}
-
-data "aws_nat_gateway" "main_one" {
-  tags = map("Name", "nat-gateway-1-tdr-${local.environment}")
-}


### PR DESCRIPTION
- Add depends_on for the lambda.
- Remove data blocks from root_data and use the module outputs directly
- Export fields needed by other modules
- Output the mount targets which are used by the lambdas
- Remove the CreateLogGroup permission
