### PR TITLE
Change the log format

### DIFF
--- a/modules/consignment-api/templates/consignment-api.json.tpl
+++ b/modules/consignment-api/templates/consignment-api.json.tpl
@@ -42,7 +42,7 @@
         "awslogs-group": "/ecs/consignment-api-${app_environment}",
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "ecs",
-        "awslogs-datetime-format": "%H:%M:%S.%L"
+        "awslogs-datetime-format": "%H:%M:%S%L"
       }
     },
     "portMappings": [

--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -66,7 +66,7 @@
         "awslogs-group": "/ecs/keycloak-${app_environment}",
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "ecs",
-        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S,%L"
+        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S%L"
       }
     },
     "portMappings": [

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -50,7 +50,7 @@
         "awslogs-group": "/ecs/frontend-${app_environment}",
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "ecs",
-        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S,%L"
+        "awslogs-datetime-format": "%Y-%m-%d %H:%M:%S%L"
       }
     },
     "portMappings": [


### PR DESCRIPTION
The %L option includes the leading dot and can't be ignored.
For the consignment api, this is just a case of removing the dot.
For the other two, I've removed the comma and there are PRs to update
the log configuration to use a dot before the milliseconds
https://github.com/nationalarchives/tdr-auth-server/pull/81
https://github.com/nationalarchives/tdr-transfer-frontend/pull/494
