### PR TITLE
Add read replicas to keycloak and consignment api databases

### DIFF
--- a/modules/consignment-api/database.tf
+++ b/modules/consignment-api/database.tf
@@ -55,7 +55,7 @@ resource "aws_rds_cluster" "consignment_api_database" {
 }
 
 resource "aws_rds_cluster_instance" "content_database" {
-  count                = 1
+  count                = 2
   identifier_prefix    = "content-db-postgres-instance-${var.environment}"
   cluster_identifier   = aws_rds_cluster.consignment_api_database.id
   engine               = "aurora-postgresql"

--- a/modules/keycloak/database.tf
+++ b/modules/keycloak/database.tf
@@ -55,7 +55,7 @@ resource "aws_rds_cluster" "keycloak_database" {
 }
 
 resource "aws_rds_cluster_instance" "user_database_instance" {
-  count                = 1
+  count                = 2
   identifier_prefix    = "content-db-postgres-instance-${var.environment}"
   cluster_identifier   = aws_rds_cluster.keycloak_database.id
   engine               = "aurora-postgresql"


### PR DESCRIPTION
Either terraform or AWS is clever enough to know that if you want more than one instance in your cluster, the second on is a read replica. I've tested this and it is working.
