### PR TITLE
Only allow host from keycloak

### DIFF
--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -10,6 +10,10 @@ output alb_security_group_id {
   value = aws_security_group.lb.id
 }
 
+output "auth_host" {
+  value = "${aws_route53_record.keycloak_dns.name}.${var.dns_zone_name_trimmed}"
+}
+
 output "auth_url" {
   value = "https://${aws_route53_record.keycloak_dns.name}.${var.dns_zone_name_trimmed}/auth"
 }

--- a/root.tf
+++ b/root.tf
@@ -173,8 +173,8 @@ module "keycloak_alb" {
   public_subnets        = module.keycloak.public_subnets
   vpc_id                = module.keycloak.vpc_id
   common_tags           = local.common_tags
-  own_host_header_only = true
-  host = module.keycloak.auth_host
+  own_host_header_only  = true
+  host                  = module.keycloak.auth_host
 }
 
 module "frontend_certificate" {

--- a/root.tf
+++ b/root.tf
@@ -173,6 +173,8 @@ module "keycloak_alb" {
   public_subnets        = module.keycloak.public_subnets
   vpc_id                = module.keycloak.vpc_id
   common_tags           = local.common_tags
+  own_host_header_only = true
+  host = module.keycloak.auth_host
 }
 
 module "frontend_certificate" {


### PR DESCRIPTION
This sets the own_host_header_only value to true which sets the load balancer listener up as it is in https://github.com/nationalarchives/tdr-terraform-modules/pull/96.

Also, I'm outputting the auth domain as we only had it in https://domain/auth format before.
