### PR TITLE
Fetch WAF allow list from tdr-configurations instead of SSM param

### DIFF
--- a/modules/consignment-api/security.tf
+++ b/modules/consignment-api/security.tf
@@ -54,7 +54,7 @@ resource "aws_security_group" "lb" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = var.ip_whitelist
+    cidr_blocks = var.ip_allowlist
   }
 
   egress {

--- a/modules/consignment-api/variables.tf
+++ b/modules/consignment-api/variables.tf
@@ -34,7 +34,7 @@ variable "vpc_id" {}
 
 variable "dns_zone_name_trimmed" {}
 
-variable "ip_whitelist" {
+variable "ip_allowlist" {
   description = "IP addresses allowed to access"
   default     = ["0.0.0.0/0"]
 }

--- a/modules/keycloak/security.tf
+++ b/modules/keycloak/security.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "lb" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = var.ip_whitelist
+    cidr_blocks = var.ip_allowlist
   }
 
   egress {

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -24,7 +24,7 @@ variable "region" {}
 
 variable "frontend_url" {}
 
-variable "ip_whitelist" {
+variable "ip_allowlist" {
   description = "IP addresses allowed to access"
   default     = ["0.0.0.0/0"]
 }

--- a/modules/transfer-frontend/security.tf
+++ b/modules/transfer-frontend/security.tf
@@ -7,14 +7,14 @@ resource "aws_security_group" "lb" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = var.ip_whitelist
+    cidr_blocks = var.ip_allowlist
   }
 
   ingress {
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
-    cidr_blocks = var.ip_whitelist
+    cidr_blocks = var.ip_allowlist
   }
 
   egress {

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -28,7 +28,7 @@ variable "auth_url" {}
 
 variable "client_secret_path" {}
 
-variable "ip_whitelist" {
+variable "ip_allowlist" {
   description = "IP addresses allowed to access"
   default     = ["0.0.0.0/0"]
 }

--- a/root.tf
+++ b/root.tf
@@ -224,7 +224,7 @@ module "waf" {
   environment       = local.environment
   common_tags       = local.common_tags
   alb_target_groups = [module.keycloak_alb.alb_arn, module.consignment_api_alb.alb_arn, module.frontend_alb.alb_arn]
-  trusted_ips       = concat(split(",", data.aws_ssm_parameter.trusted_ips.value), list("${module.shared_vpc.nat_gateway_public_ips[0]}/32", "${module.shared_vpc.nat_gateway_public_ips[1]}/32"))
+  trusted_ips       = concat(local.ip_whitelist, list("${module.shared_vpc.nat_gateway_public_ips[0]}/32", "${module.shared_vpc.nat_gateway_public_ips[1]}/32"))
   geo_match         = split(",", var.geo_match)
   restricted_uri    = "auth/admin"
 }

--- a/root.tf
+++ b/root.tf
@@ -53,7 +53,7 @@ module "frontend" {
   environment           = local.environment
   environment_full_name = local.environment_full_name_map[local.environment]
   common_tags           = local.common_tags
-  ip_whitelist          = local.environment == "intg" ? local.ip_whitelist : ["0.0.0.0/0"]
+  ip_allowlist          = local.environment == "intg" ? local.ip_allowlist : ["0.0.0.0/0"]
   region                = local.region
   vpc_id                = module.shared_vpc.vpc_id
   public_subnets        = module.shared_vpc.public_subnets
@@ -224,7 +224,7 @@ module "waf" {
   environment       = local.environment
   common_tags       = local.common_tags
   alb_target_groups = [module.keycloak_alb.alb_arn, module.consignment_api_alb.alb_arn, module.frontend_alb.alb_arn]
-  trusted_ips       = concat(local.ip_whitelist, list("${module.shared_vpc.nat_gateway_public_ips[0]}/32", "${module.shared_vpc.nat_gateway_public_ips[1]}/32"))
+  trusted_ips       = concat(local.ip_allowlist, list("${module.shared_vpc.nat_gateway_public_ips[0]}/32", "${module.shared_vpc.nat_gateway_public_ips[1]}/32"))
   geo_match         = split(",", var.geo_match)
   restricted_uri    = "auth/admin"
 }

--- a/root_data.tf
+++ b/root_data.tf
@@ -2,10 +2,6 @@ data "aws_ssm_parameter" "cost_centre" {
   name = "/mgmt/cost_centre"
 }
 
-data "aws_ssm_parameter" "trusted_ips" {
-  name = "/mgmt/trusted_ips"
-}
-
 data "aws_route53_zone" "tdr_dns_zone" {
   name = local.environment == "prod" ? "${var.project}.${var.domain}" : "${var.project}-${local.environment_full_name}.${var.domain}"
 }

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -35,5 +35,5 @@ locals {
 
   trusted_ip_list = split(",", module.global_parameters.trusted_ips)
 
-  ip_whitelist = concat(local.developer_ip_list, local.trusted_ip_list)
+  ip_allowlist = concat(local.developer_ip_list, local.trusted_ip_list)
 }


### PR DESCRIPTION
This changes where the list of IPs which are allowed to access Keycloak admin URLs is read from.

Before, we read the list from a parameter in the AWS SSM Parameter Store. Now, it reads the list from the tdr-configurations repo.

The tdr-configurations repo was already being used for the frontend load balancer allow list, so this change makes the WAF consistent with the frontend.

It also reduces the number of deployment steps. When the list changes, we can now deploy the changes by running this Terraform project, without having to deploy the change to the parameter store first.

Also rename "whitelist" to "allow list" to match the GOV.UK styleguide: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#allow-list