### PR TITLE
Specify KMS policy for encryption key

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -211,6 +211,7 @@ module "encryption_key" {
   source      = "./tdr-terraform-modules/kms"
   project     = var.project
   function    = "encryption"
+  key_policy  = "message_system_access"
   environment = local.environment
   common_tags = local.common_tags
 }


### PR DESCRIPTION
The default policy in tdr-terraform-modules is being changed, so this Terraform script now needs to specify the policy to use. The relevant policy is the one which allows SNS and SQS to use the KMS key.

See https://github.com/nationalarchives/tdr-terraform-modules/pull/102 for more about why the default is changing.