### PR TITLE
Add IP restriction to prod S3 export bucket

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -519,10 +519,12 @@ module "export_step_function" {
 }
 
 module "export_bucket" {
-  source      = "./tdr-terraform-modules/s3"
-  project     = var.project
-  function    = "consignment-export"
-  common_tags = local.common_tags
+  source              = "./tdr-terraform-modules/s3"
+  project             = var.project
+  function            = "consignment-export"
+  common_tags         = local.common_tags
+  ip_restriction      = local.ip_s3_export_restriction
+  ip_bucket_allowlist = local.ip_s3_export_allowlist
 }
 
 module "notifications_topic" {

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -35,5 +35,11 @@ locals {
 
   trusted_ip_list = split(",", module.global_parameters.trusted_ips)
 
+  tna_corporate_ip_list = split(",", module.global_parameters.tna_corporate_ips)
+
   ip_allowlist = concat(local.developer_ip_list, local.trusted_ip_list)
+
+  ip_s3_export_restriction = local.environment == "prod" ? true : false
+
+  ip_s3_export_allowlist = local.environment == "prod" ? local.tna_corporate_ip_list : concat(local.developer_ip_list, local.trusted_ip_list)
 }


### PR DESCRIPTION
Requires PR:

- https://github.com/nationalarchives/tdr-terraform-modules/pull/105
- https://github.com/nationalarchives/tdr-configurations/pull/67

Expected further S3 buckets will have IP restrictions introduced.