### PR TITLE
Change health check expected code for frontend ALB

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -197,12 +197,12 @@ module "frontend_alb" {
   alb_target_group_port = 9000
   alb_target_type       = "ip"
   certificate_arn       = module.frontend_certificate.certificate_arn
-  // The front end returns 308 for any non https requests and the health checks are not https. The play app needs to be running to return 308 so this still works as a health check.
-  health_check_matcher  = "308"
-  health_check_path     = ""
-  public_subnets        = module.shared_vpc.public_subnets
-  vpc_id                = module.shared_vpc.vpc_id
-  common_tags           = local.common_tags
+  # The front end returns 308 for any non https requests and the health checks are not https. The play app needs to be running to return 308 so this still works as a health check.
+  health_check_matcher = "308"
+  health_check_path    = ""
+  public_subnets       = module.shared_vpc.public_subnets
+  vpc_id               = module.shared_vpc.vpc_id
+  common_tags          = local.common_tags
 }
 
 module "encryption_key" {

--- a/root.tf
+++ b/root.tf
@@ -197,7 +197,7 @@ module "frontend_alb" {
   alb_target_group_port = 9000
   alb_target_type       = "ip"
   certificate_arn       = module.frontend_certificate.certificate_arn
-  health_check_matcher  = "200,303"
+  health_check_matcher  = "308"
   health_check_path     = ""
   public_subnets        = module.shared_vpc.public_subnets
   vpc_id                = module.shared_vpc.vpc_id

--- a/root.tf
+++ b/root.tf
@@ -197,6 +197,7 @@ module "frontend_alb" {
   alb_target_group_port = 9000
   alb_target_type       = "ip"
   certificate_arn       = module.frontend_certificate.certificate_arn
+  // The front end returns 308 for any non https requests and the health checks are not https. The play app needs to be running to return 308 so this still works as a health check.
   health_check_matcher  = "308"
   health_check_path     = ""
   public_subnets        = module.shared_vpc.public_subnets


### PR DESCRIPTION
This PR https://github.com/nationalarchives/tdr-transfer-frontend/pull/678 enables strict transport security. The load balancer requests are over http and they won't send the correct headers the load balancer does for requests from external clients that lets play treat it as http so you get a 308 response from any health check requests.

This isn't the only way to do it, we could have a dedicated healthcheck url in the play application and disable strict transport security for that url but this seems cleaner.
