### PR TITLE
Add new default tag for Terraform source

### DIFF
--- a/root_locals.tf
+++ b/root_locals.tf
@@ -15,6 +15,7 @@ locals {
     "Environment", local.environment,
     "Owner", "TDR",
     "Terraform", true,
+    "TerraformSource", "https://github.com/nationalarchives/tdr-terraform-environments",
     "CostCentre", data.aws_ssm_parameter.cost_centre.value,
   )
   database_availability_zones = ["eu-west-2a", "eu-west-2b"]


### PR DESCRIPTION
Add `TerraformSource` tag which links to this code repo. This will make it easier for devs to find the Terraform source which created a particular resource in the AWS console.