### PR TITLE
Increase the message visibility timeout for file checks

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -242,7 +242,7 @@ module "antivirus_lambda" {
   common_tags                            = local.common_tags
   file_system_id                         = module.backend_checks_efs.file_system_id
   lambda_yara_av                         = true
-  timeout_seconds                        = 180
+  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["antivirus"]
   project                                = var.project
   use_efs                                = true
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -258,7 +258,7 @@ module "checksum_lambda" {
   project                                = var.project
   common_tags                            = local.common_tags
   lambda_checksum                        = true
-  timeout_seconds                        = 180
+  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["checksum"]
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -406,7 +406,7 @@ module "api_update_lambda" {
   project                               = var.project
   common_tags                           = local.common_tags
   lambda_api_update                     = true
-  timeout_seconds                       = 20
+  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["api_update"]
   auth_url                              = module.keycloak.auth_url
   api_url                               = module.consignment_api.api_url
   keycloak_backend_checks_client_secret = module.keycloak.backend_checks_client_secret
@@ -420,7 +420,7 @@ module "file_format_lambda" {
   project                                = var.project
   common_tags                            = local.common_tags
   lambda_file_format                     = true
-  timeout_seconds                        = 900
+  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["file_format"]
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -438,7 +438,7 @@ module "download_files_lambda" {
   common_tags                            = local.common_tags
   project                                = var.project
   lambda_download_files                  = true
-  timeout_seconds                        = 180
+  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["download_files"]
   s3_sns_topic                           = module.dirty_upload_sns_topic.sns_arn
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point

--- a/root.tf
+++ b/root.tf
@@ -242,6 +242,7 @@ module "antivirus_lambda" {
   common_tags                            = local.common_tags
   file_system_id                         = module.backend_checks_efs.file_system_id
   lambda_yara_av                         = true
+  timeout_seconds                        = 180
   project                                = var.project
   use_efs                                = true
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -257,6 +258,7 @@ module "checksum_lambda" {
   project                                = var.project
   common_tags                            = local.common_tags
   lambda_checksum                        = true
+  timeout_seconds                        = 180
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -404,6 +406,7 @@ module "api_update_lambda" {
   project                               = var.project
   common_tags                           = local.common_tags
   lambda_api_update                     = true
+  timeout_seconds                       = 20
   auth_url                              = module.keycloak.auth_url
   api_url                               = module.consignment_api.api_url
   keycloak_backend_checks_client_secret = module.keycloak.backend_checks_client_secret
@@ -417,6 +420,7 @@ module "file_format_lambda" {
   project                                = var.project
   common_tags                            = local.common_tags
   lambda_file_format                     = true
+  timeout_seconds                        = 900
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
   vpc_id                                 = module.shared_vpc.vpc_id
@@ -434,6 +438,7 @@ module "download_files_lambda" {
   common_tags                            = local.common_tags
   project                                = var.project
   lambda_download_files                  = true
+  timeout_seconds                        = 180
   s3_sns_topic                           = module.dirty_upload_sns_topic.sns_arn
   file_system_id                         = module.backend_checks_efs.file_system_id
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
@@ -485,6 +490,7 @@ module "export_authoriser_lambda" {
   common_tags              = local.common_tags
   project                  = "tdr"
   lambda_export_authoriser = true
+  timeout_seconds          = 10
   api_url                  = module.consignment_api.api_url
   api_gateway_arn          = module.export_api.api_arn
   kms_key_arn              = module.encryption_key.kms_key_arn

--- a/root.tf
+++ b/root.tf
@@ -347,7 +347,7 @@ module "antivirus_sqs_queue" {
   sqs_policy               = "file_checks"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout       = 180
+  visibility_timeout       = local.file_check_lambda_timeouts_in_seconds["antivirus"] * 3
   kms_key_id               = module.encryption_key.kms_key_arn
 }
 
@@ -360,7 +360,7 @@ module "download_files_sqs_queue" {
   sqs_policy               = "sns_topic"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout       = 180
+  visibility_timeout       = local.file_check_lambda_timeouts_in_seconds["download_files"] * 3
   kms_key_id               = module.encryption_key.kms_key_arn
 }
 
@@ -372,7 +372,7 @@ module "checksum_sqs_queue" {
   sqs_policy               = "file_checks"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  visibility_timeout       = 180
+  visibility_timeout       = local.file_check_lambda_timeouts_in_seconds["checksum"] * 3
   kms_key_id               = module.encryption_key.kms_key_arn
 }
 
@@ -384,10 +384,8 @@ module "file_format_sqs_queue" {
   sqs_policy               = "file_checks"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
-  // Terraform will fail if the visibility timeout is shorter than the lambda timeout.
-  // The timeout for the file format lambda is set to 900 seconds, more than the other backend check lambdas because the file format lambda is slower than the others
-  visibility_timeout = 900
-  kms_key_id         = module.encryption_key.kms_key_arn
+  visibility_timeout       = local.file_check_lambda_timeouts_in_seconds["file_format"] * 3
+  kms_key_id               = module.encryption_key.kms_key_arn
 }
 
 module "api_update_queue" {
@@ -398,6 +396,7 @@ module "api_update_queue" {
   sqs_policy               = "api_update_antivirus"
   dead_letter_queue        = module.backend_check_failure_sqs_queue.sqs_arn
   redrive_maximum_receives = 3
+  visibility_timeout       = local.file_check_lambda_timeouts_in_seconds["api_update"] * 3
   kms_key_id               = module.encryption_key.kms_key_arn
 }
 
@@ -406,7 +405,7 @@ module "api_update_lambda" {
   project                               = var.project
   common_tags                           = local.common_tags
   lambda_api_update                     = true
-  timeout_seconds                        = local.file_check_lambda_timeouts_in_seconds["api_update"]
+  timeout_seconds                       = local.file_check_lambda_timeouts_in_seconds["api_update"]
   auth_url                              = module.keycloak.auth_url
   api_url                               = module.consignment_api.api_url
   keycloak_backend_checks_client_secret = module.keycloak.backend_checks_client_secret

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -34,6 +34,14 @@ locals {
 
   upload_cors_urls = local.environment == "intg" ? [module.frontend.frontend_url, local.local_dev_frontend_url] : [module.frontend.frontend_url]
 
+  file_check_lambda_timeouts_in_seconds = {
+    "antivirus"      = 180,
+    "api_update"     = 20,
+    "checksum"       = 180,
+    "download_files" = 180,
+    "file_format"    = 900
+  }
+
   developer_ip_list = split(",", module.global_parameters.developer_ips)
 
   trusted_ip_list = split(",", module.global_parameters.trusted_ips)


### PR DESCRIPTION
Set the SQS message visibility timeout to be three times the lambda timeout for each of the file check lambdas, including the file download and API update lambda.

This should prevent messages from being sent to the failure queue incorrectly. See ADR 20 for how this change works: nationalarchives/tdr-dev-documentation#122

This will make retries slower, because the message visibility timeout has to expire before a failed file check is retried. The plan is to add extra error handling to the file checks which sets the message visibility timeout to zero to cause the check to be retried immediately.

Marking as a draft PR until https://github.com/nationalarchives/tdr-terraform-modules/pull/124 is merged.