### PR TITLE
Set reserved concurrency to 3

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -450,6 +450,7 @@ module "download_files_lambda" {
   backend_checks_client_secret           = module.keycloak.backend_checks_client_secret
   kms_key_arn                            = module.encryption_key.kms_key_arn
   efs_security_group_id                  = module.backend_checks_efs.security_group_id
+  reserved_concurrency                   = 3
 }
 
 module "service_unavailable_lambda" {


### PR DESCRIPTION
There is a PR for terraform-modules
https://github.com/nationalarchives/tdr-terraform-modules/pull/130
which will need to be merged first.

There is a Jira ticket TDR-1242 which shows the results of testing
different values for reserved concurrency and 3 is about the best one.
