### PR TITLE
Add athena bucket, workspace and queries

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -646,3 +646,21 @@ module "keycloak_default_nacl" {
   source                 = "./tdr-terraform-modules/default_nacl"
   default_network_acl_id = module.keycloak.default_nacl_id
 }
+
+module "athena_s3" {
+  source         = "./tdr-terraform-modules/s3"
+  project        = var.project
+  common_tags    = local.common_tags
+  function       = "athena"
+  access_logs    = false
+}
+
+module "athena" {
+  source         = "./tdr-terraform-modules/athena"
+  project        = var.project
+  common_tags    = local.common_tags
+  function       = "security_logs"
+  bucket         = module.athena_s3.s3_bucket_id
+  environment = local.environment
+  queries        = ["keycloak_alb_logs"]
+}

--- a/root.tf
+++ b/root.tf
@@ -648,19 +648,37 @@ module "keycloak_default_nacl" {
 }
 
 module "athena_s3" {
-  source         = "./tdr-terraform-modules/s3"
-  project        = var.project
-  common_tags    = local.common_tags
-  function       = "athena"
-  access_logs    = false
+  source      = "./tdr-terraform-modules/s3"
+  project     = var.project
+  common_tags = local.common_tags
+  function    = "athena"
+  access_logs = false
 }
 
 module "athena" {
-  source         = "./tdr-terraform-modules/athena"
-  project        = var.project
-  common_tags    = local.common_tags
-  function       = "security_logs"
-  bucket         = module.athena_s3.s3_bucket_id
+  source      = "./tdr-terraform-modules/athena"
+  project     = var.project
+  common_tags = local.common_tags
+  function    = "security_logs"
+  bucket      = module.athena_s3.s3_bucket_id
   environment = local.environment
-  queries        = ["keycloak_alb_logs"]
+  queries = [
+    "create_table_keycloak_alb_logs",
+    "create_table_frontend_alb_logs",
+    "create_table_consignmentapi_alb_logs",
+    "create_table_tdr_cloudtrail_logs",
+    "create_table_tdr_s3_upload_logs",
+    "tdr_alb_client_ip_count",
+    "tdr_alb_error_counts",
+    "tdr_cloudtrail_action_for_iam_user",
+    "tdr_cloudtrail_action_for_principal",
+    "tdr_cloudtrail_action_for_role_name",
+    "tdr_cloudtrail_action_on_date",
+    "tdr_cloudtrail_ip_for_access_key",
+    "tdr_cloudtrail_update_resource",
+    "tdr_cloudtrail_user_for_access_key",
+    "tdr_s3_deleted_objects",
+    "tdr_s3_object_operations",
+    "tdr_s3_request_errors"
+  ]
 }


### PR DESCRIPTION
This uses the `tdr-terraform-modules` athena module to create an athena workspace. There's a separate PR for that repo to add the queries in, this just adds them to the workspace. I've also added in the s3 bucket to store the query results.
