### PR TITLE
Add bastion sg to inbound rules for both efs volumes.

### DIFF
--- a/modules/consignment-api/outputs.tf
+++ b/modules/consignment-api/outputs.tf
@@ -30,3 +30,7 @@ output "database_cluster_id" {
 output "database_security_group" {
   value = aws_security_group.database.id
 }
+
+output "bastion_security_group_id" {
+  value = aws_security_group.bastion_security_group.id
+}

--- a/root.tf
+++ b/root.tf
@@ -470,7 +470,7 @@ module "backend_checks_efs" {
   project                      = var.project
   access_point_path            = "/backend-checks"
   policy                       = "backend_checks_access_policy"
-  mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id, module.antivirus_lambda.antivirus_lambda_sg_id, module.checksum_lambda.checksum_lambda_sg_id])
+  mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id, module.antivirus_lambda.antivirus_lambda_sg_id, module.checksum_lambda.checksum_lambda_sg_id, module.consignment_api.bastion_security_group_id])
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
   vpc_cidr_block               = module.shared_vpc.vpc_cidr_block
   vpc_id                       = module.shared_vpc.vpc_id
@@ -519,7 +519,7 @@ module "export_efs" {
   project                      = var.project
   access_point_path            = "/export"
   policy                       = "export_access_policy"
-  mount_target_security_groups = flatten([module.export_task.consignment_export_sg_id])
+  mount_target_security_groups = flatten([module.export_task.consignment_export_sg_id, module.consignment_api.bastion_security_group_id])
   netnum_offset                = 6
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
   vpc_cidr_block               = module.shared_vpc.vpc_cidr_block


### PR DESCRIPTION
This will allow us to use the bastion to connect to the EFS volumes.
There have been a few times recently where we've needed to so this
removes the need to manually fiddle with the security groups.
