### PR TITLE
Remove bastion security group

### DIFF
--- a/modules/consignment-api/security.tf
+++ b/modules/consignment-api/security.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "database" {
     protocol        = "tcp"
     from_port       = 5432
     to_port         = 5432
-    security_groups = flatten([[aws_security_group.ecs_tasks.id, var.db_migration_sg, aws_security_group.bastion_security_group.id], var.create_users_security_group_id])
+    security_groups = flatten([[aws_security_group.ecs_tasks.id, var.db_migration_sg], var.create_users_security_group_id])
   }
 
   egress {
@@ -23,30 +23,6 @@ resource "aws_security_group" "database" {
       { "Name" = "${var.app_name}-database-security-group-${var.environment}" }
     )
   )
-}
-
-resource "aws_security_group" "bastion_security_group" {
-  name        = "${var.app_name}-database-bastion-security-group-${var.environment}"
-  description = "Security group which will be used by the bastion EC2 instance."
-  vpc_id      = var.vpc_id
-
-  tags = merge(
-    var.common_tags,
-    tomap(
-      { "Name" = "${var.app_name}-database-bastion-security-group-${var.environment}" }
-    )
-  )
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  lifecycle {
-    ignore_changes = [ingress]
-  }
 }
 
 resource "aws_security_group" "lb" {

--- a/root.tf
+++ b/root.tf
@@ -470,8 +470,8 @@ module "backend_checks_efs" {
   function                     = "backend-checks-efs"
   project                      = var.project
   access_point_path            = "/backend-checks"
-  policy                       = "backend_checks_access_policy"
-  policy_roles                 = jsonencode(flatten([module.download_files_lambda.download_files_lambda_role, module.file_format_lambda.file_format_lambda_role, module.file_format_build_task.file_format_build_role, module.checksum_lambda.checksum_lambda_role, module.antivirus_lambda.antivirus_lambda_role]))
+  policy                       = "efs_access_policy"
+  policy_roles                 = jsonencode(flatten([module.file_format_build_task.file_format_build_role, module.checksum_lambda.checksum_lambda_role, module.antivirus_lambda.antivirus_lambda_role, module.download_files_lambda.download_files_lambda_role, module.file_format_lambda.file_format_lambda_role]))
   bastion_role                 = module.bastion_role.role.arn
   mount_target_security_groups = flatten([module.file_format_lambda.file_format_lambda_sg_id, module.download_files_lambda.download_files_lambda_sg_id, module.file_format_build_task.file_format_build_sg_id, module.antivirus_lambda.antivirus_lambda_sg_id, module.checksum_lambda.checksum_lambda_sg_id])
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
@@ -521,8 +521,10 @@ module "export_efs" {
   function                     = "export-efs"
   project                      = var.project
   access_point_path            = "/export"
-  policy                       = "export_access_policy"
+  policy                       = "efs_access_policy"
+  policy_roles                 = jsonencode(module.export_task.consignment_export_task_role_arn)
   mount_target_security_groups = flatten([module.export_task.consignment_export_sg_id])
+  bastion_role                 = module.bastion_role.role.arn
   netnum_offset                = 6
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
   vpc_cidr_block               = module.shared_vpc.vpc_cidr_block


### PR DESCRIPTION
- Remove bastion security group. This is now created when the bastion is created and the rule to allow the security group to access EFS is now added in in the bastion terraform.
- Modify the export EFS policy to use specific IAM roles. This allows the backend checks and export roles to read and write and the bastion role to only read.
- Create the bastion role. This needs to always exist as you can't add a role to an EFS policy if it doesn't exist and you can't update an existing EFS policy in a separate terraform project. It has no policies attached to it though, these are attached in the bastion terraform so the role is useless until that is run.
