### PR TITLE
Add s3 bucket and origin access identity.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -132,7 +132,7 @@ module "upload_file_cloudfront_dirty_s3" {
   bucket_policy            = "cloudfront_oai"
   sns_notification         = true
   abort_incomplete_uploads = true
-  cloudfront_oai           = module.cloudwatch_upload.oai_iam_arn
+  cloudfront_oai           = module.cloudwatch_upload.cloudfront_oai_iam_arn
 }
 
 module "cloudwatch_upload" {

--- a/root.tf
+++ b/root.tf
@@ -122,6 +122,23 @@ module "upload_file_dirty_s3" {
   abort_incomplete_uploads = true
 }
 
+module "upload_file_cloudfront_dirty_s3" {
+  source                   = "./tdr-terraform-modules/s3"
+  project                  = var.project
+  function                 = "upload-files-cloudfront-dirty"
+  common_tags              = local.common_tags
+  cors_urls                = local.upload_cors_urls
+  sns_topic_arn            = module.dirty_upload_sns_topic.sns_arn
+  bucket_policy            = "cloudfront_oai"
+  sns_notification         = true
+  abort_incomplete_uploads = true
+  cloudfront_oai           = module.cloudwatch_upload.oai_iam_arn
+}
+
+module "cloudwatch_upload" {
+  source = "./tdr-terraform-modules/cloudfront"
+}
+
 module "consignment_api_certificate" {
   source      = "./tdr-terraform-modules/certificatemanager"
   project     = var.project


### PR DESCRIPTION
The cloudwatch module at the moment only creates an origin access
identity which is needed to pass into the bucket policy.

I'll add in other resources to the Cloudwatch module later.

This needs
https://github.com/nationalarchives/tdr-terraform-modules/pull/140 to be
merged before this can be.
