### PR TITLE
Add cloudfront distribution and log bucket.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -135,8 +135,19 @@ module "upload_file_cloudfront_dirty_s3" {
   cloudfront_oai           = module.cloudwatch_upload.cloudfront_oai_iam_arn
 }
 
+module "upload_file_cloudfront_logs" {
+  source      = "./tdr-terraform-modules/s3"
+  project     = var.project
+  function    = "upload-cloudfront-logs"
+  common_tags = local.common_tags
+  access_logs = false
+}
+
 module "cloudwatch_upload" {
-  source = "./tdr-terraform-modules/cloudfront"
+  source                              = "./tdr-terraform-modules/cloudfront"
+  s3_regional_domain_name             = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
+  environment                         = local.environment
+  logging_bucket_regional_domain_name = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
 }
 
 module "consignment_api_certificate" {

--- a/root.tf
+++ b/root.tf
@@ -147,7 +147,7 @@ module "cloudfront_upload" {
   source                              = "./tdr-terraform-modules/cloudfront"
   s3_regional_domain_name             = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
   environment                         = local.environment
-  logging_bucket_regional_domain_name = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
+  logging_bucket_regional_domain_name = module.upload_file_cloudfront_logs.s3_bucket_regional_domain_name
 }
 
 module "consignment_api_certificate" {

--- a/root.tf
+++ b/root.tf
@@ -132,7 +132,7 @@ module "upload_file_cloudfront_dirty_s3" {
   bucket_policy            = "cloudfront_oai"
   sns_notification         = true
   abort_incomplete_uploads = true
-  cloudfront_oai           = module.cloudwatch_upload.cloudfront_oai_iam_arn
+  cloudfront_oai           = module.cloudfront_upload.cloudfront_oai_iam_arn
 }
 
 module "upload_file_cloudfront_logs" {
@@ -143,7 +143,7 @@ module "upload_file_cloudfront_logs" {
   access_logs = false
 }
 
-module "cloudwatch_upload" {
+module "cloudfront_upload" {
   source                              = "./tdr-terraform-modules/cloudfront"
   s3_regional_domain_name             = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
   environment                         = local.environment


### PR DESCRIPTION
This log bucket is for logging cloudfront requests so we want versioning
enabled but we don't need a log bucket for the log bucket.
