### PR TITLE
Add DNS and Cloudfront ACM certificate

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -148,6 +148,17 @@ module "cloudwatch_upload" {
   s3_regional_domain_name             = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
   environment                         = local.environment
   logging_bucket_regional_domain_name = module.upload_file_cloudfront_dirty_s3.s3_bucket_regional_domain_name
+  alias_domain_name                   = local.upload_domain
+  certificate_arn                     = module.cloudfront_certificate.certificate_arn
+}
+
+module "cloudfront_upload_dns" {
+  source                = "./tdr-terraform-modules/route53"
+  common_tags           = local.common_tags
+  environment_full_name = local.environment_full_name
+  project               = var.project
+  create_hosted_zone    = false
+  a_record_name         = "upload"
 }
 
 module "consignment_api_certificate" {
@@ -157,6 +168,18 @@ module "consignment_api_certificate" {
   dns_zone    = local.environment_domain
   domain_name = "api.${local.environment_domain}"
   common_tags = local.common_tags
+}
+
+module "cloudfront_certificate" {
+  source      = "./tdr-terraform-modules/certificatemanager"
+  common_tags = local.common_tags
+  dns_zone    = local.environment_domain
+  domain_name = local.upload_domain
+  function    = "cloudfront-upload"
+  project     = var.project
+  providers = {
+    aws = aws.useast1
+  }
 }
 
 module "consignment_api_alb" {

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -30,6 +30,8 @@ locals {
 
   environment_domain = local.environment == "prod" ? "${var.project}.${var.domain}" : "${var.project}-${local.environment_full_name}.${var.domain}"
 
+  upload_domain = "upload.${local.environment_domain}"
+
   local_dev_frontend_url = "http://localhost:9000"
 
   upload_cors_urls = local.environment == "intg" ? [module.frontend.frontend_url, local.local_dev_frontend_url] : [module.frontend.frontend_url]

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -6,3 +6,13 @@ provider "aws" {
     session_name = "terraform"
   }
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "useast1"
+
+  assume_role {
+    role_arn     = local.assume_role
+    session_name = "terraform"
+  }
+}


### PR DESCRIPTION
The second provider is needed because the certificate needs to be
created in us-east-1.
