### PR TITLE
Add PROXY_ADDRESS_FORWARDING variable

### DIFF
--- a/modules/keycloak/templates/keycloak.json.tpl
+++ b/modules/keycloak/templates/keycloak.json.tpl
@@ -55,6 +55,10 @@
     ],
     "environment": [
       {
+        "name": "PROXY_ADDRESS_FORWARDING",
+        "value": "true"
+      },
+      {
         "name" : "FRONTEND_URL",
         "value" : "${frontend_url}"
       },


### PR DESCRIPTION
This is needed for keycloak to work out https urls. Without it, it tries
to serve keycloak js over http and the browser gets upset.
