### PR TITLE
Move consignment export task

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -617,7 +617,7 @@ module "export_step_function" {
   definition             = "consignment_export"
   environment            = local.environment
   step_function_name     = "ConsignmentExport"
-  definition_variables   = { security_groups = jsonencode(module.consignment_export_ecs_security_group.security_group_id), subnet_ids = jsonencode(module.export_efs.private_subnets), cluster_arn = module.consignment_export_ecs_task.cluster_arn, task_arn = module.consignment_export_ecs_task.task_definition_arn, task_name = "consignment-export", sns_topic = module.notifications_topic.sns_arn }
+  definition_variables   = { security_groups = jsonencode([module.consignment_export_ecs_security_group.security_group_id]), subnet_ids = jsonencode(module.export_efs.private_subnets), cluster_arn = module.consignment_export_ecs_task.cluster_arn, task_arn = module.consignment_export_ecs_task.task_definition_arn, task_name = "consignment-export", sns_topic = module.notifications_topic.sns_arn }
   policy                 = "consignment_export"
   policy_variables       = { task_arn = module.consignment_export_ecs_task.task_definition_arn, execution_role = module.consignment_export_execution_role.role.arn, task_role = module.consignment_export_task_role.role.arn, kms_key_arn = module.encryption_key.kms_key_arn }
   notification_sns_topic = module.notifications_topic.sns_arn

--- a/root_consignment_export.tf
+++ b/root_consignment_export.tf
@@ -1,0 +1,75 @@
+module "consignment_export_ecs_security_group" {
+  source            = "./tdr-terraform-modules/security_group"
+  description       = "Controls access within our network for the Keycloak ECS Task"
+  name              = "consignment-export-allow-ecs-mount-efs"
+  vpc_id            = module.shared_vpc.vpc_id
+  common_tags       = local.common_tags
+  egress_cidr_rules = [{ port = 0, cidr_blocks = ["0.0.0.0/0"], description = "Allow outbound access on all ports", protocol = "-1" }]
+}
+
+module "consignment_export_cloudwatch" {
+  source      = "./tdr-terraform-modules/cloudwatch_logs"
+  common_tags = local.common_tags
+  name        = "/ecs/consignment-export-${local.environment}"
+}
+
+module "consignment_export_execution_role" {
+  source             = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
+  common_tags        = local.common_tags
+  name               = "ConsignmentExportECSExecutionRole${title(local.environment)}"
+  policy_attachments = {
+    execution_policy = module.consignment_export_execution_policy.policy_arn,
+    ssm_policy       = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+  }
+}
+
+module "consignment_export_task_role" {
+  source             = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
+  common_tags        = local.common_tags
+  name               = "ConsignmentExportECSTaskRole${title(local.environment)}"
+  policy_attachments = {
+    task_policy = module.consignment_export_task_policy.policy_arn
+  }
+}
+
+module "consignment_export_execution_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "ConsignmentExportECSExecutionPolicy${title(local.environment)}"
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/consignment_export_execution_policy.json.tpl", { log_group_arn = "${module.consignment_export_cloudwatch.log_group_arn}:*", file_system_arn = module.export_efs.file_system_arn, management_account_number = data.aws_ssm_parameter.mgmt_account_number.value })
+}
+
+module "consignment_export_task_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "ConsignmentExportECSTaskPolicy${title(local.environment)}"
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/consignment_export_task_policy.json.tpl", { environment = local.environment, titleEnvironment = title(local.environment), aws_region = local.region, account = data.aws_caller_identity.current.account_id })
+}
+
+module "consignment_export_ecs_task" {
+  source       = "./tdr-terraform-modules/generic_ecs"
+  cluster_name = "consignment_export_${local.environment}"
+  common_tags  = local.common_tags
+  container_definition = templatefile(
+    "${path.module}/templates/ecs_tasks/consignment_export.json.tpl", {
+      log_group_name             = module.consignment_export_cloudwatch.log_group_name,
+      app_environment            = local.environment,
+      management_account         = data.aws_ssm_parameter.mgmt_account_number.value,
+      backend_client_secret_path = module.keycloak_ssm_parameters.params[local.keycloak_backend_checks_secret_name].name
+      clean_bucket               = module.upload_bucket.s3_bucket_name
+      output_bucket              = module.export_bucket.s3_bucket_name
+      api_url                    = "${module.consignment_api.api_url}/graphql"
+      auth_url                   = local.keycloak_auth_url
+      region                     = local.region
+  })
+  container_name   = "consignmentexport"
+  cpu              = 512
+  environment      = local.environment
+  execution_role   = module.consignment_export_execution_role.role.arn
+  memory           = 1024
+  private_subnets  = module.shared_vpc.private_subnets
+  security_groups  = [module.consignment_export_ecs_security_group.security_group_id]
+  task_family_name = "consignment-export-${local.environment}"
+  task_role        = module.consignment_export_task_role.role.arn
+  file_systems     = [{ file_system_id = module.export_efs.file_system_id, access_point_id = module.export_efs.access_point.id }]
+}

--- a/root_consignment_export.tf
+++ b/root_consignment_export.tf
@@ -1,6 +1,6 @@
 module "consignment_export_ecs_security_group" {
   source            = "./tdr-terraform-modules/security_group"
-  description       = "Controls access within our network for the Keycloak ECS Task"
+  description       = "Allow Consignment Export ECS task to mount EFS volume"
   name              = "consignment-export-allow-ecs-mount-efs"
   vpc_id            = module.shared_vpc.vpc_id
   common_tags       = local.common_tags
@@ -17,7 +17,7 @@ module "consignment_export_execution_role" {
   source             = "./tdr-terraform-modules/iam_role"
   assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
   common_tags        = local.common_tags
-  name               = "ConsignmentExportECSExecutionRole${title(local.environment)}"
+  name               = "TDRConsignmentExportECSExecutionRole${title(local.environment)}"
   policy_attachments = {
     execution_policy = module.consignment_export_execution_policy.policy_arn,
     ssm_policy       = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
@@ -28,7 +28,7 @@ module "consignment_export_task_role" {
   source             = "./tdr-terraform-modules/iam_role"
   assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
   common_tags        = local.common_tags
-  name               = "ConsignmentExportECSTaskRole${title(local.environment)}"
+  name               = "TDRConsignmentExportEcsTaskRole${title(local.environment)}"
   policy_attachments = {
     task_policy = module.consignment_export_task_policy.policy_arn
   }
@@ -36,13 +36,13 @@ module "consignment_export_task_role" {
 
 module "consignment_export_execution_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
-  name          = "ConsignmentExportECSExecutionPolicy${title(local.environment)}"
+  name          = "TDRConsignmentExportECSExecutionPolicy${title(local.environment)}"
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/consignment_export_execution_policy.json.tpl", { log_group_arn = "${module.consignment_export_cloudwatch.log_group_arn}:*", file_system_arn = module.export_efs.file_system_arn, management_account_number = data.aws_ssm_parameter.mgmt_account_number.value })
 }
 
 module "consignment_export_task_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
-  name          = "ConsignmentExportECSTaskPolicy${title(local.environment)}"
+  name          = "TDRConsignmentExportECSTaskPolicy${title(local.environment)}"
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/consignment_export_task_policy.json.tpl", { environment = local.environment, titleEnvironment = title(local.environment), aws_region = local.region, account = data.aws_caller_identity.current.account_id })
 }
 

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -52,6 +52,8 @@ locals {
 
   ecr_account_number = local.environment == "sbox" ? data.aws_caller_identity.current.account_id : data.aws_ssm_parameter.mgmt_account_number.value
 
+  keycloak_auth_url = "https://auth.${local.dns_zone_name_trimmed}/auth"
+
   keycloak_backend_checks_secret_name     = "/${local.environment}/keycloak/new/backend_checks_client/secret"
   keycloak_tdr_client_secret_name         = "/${local.environment}/keycloak/new/client/secret"
   keycloak_user_password_name             = "/${local.environment}/keycloak/new/password"

--- a/templates/ecs_tasks/consignment_export.json.tpl
+++ b/templates/ecs_tasks/consignment_export.json.tpl
@@ -1,0 +1,45 @@
+[
+  {
+    "name": "consignmentexport",
+    "image": "${management_account}.dkr.ecr.${region}.amazonaws.com/consignment-export:${app_environment}",
+    "networkMode": "awsvpc",
+    "secrets": [
+      {
+        "name": "CLIENT_SECRET",
+        "valueFrom": "${backend_client_secret_path}"
+      }
+    ],
+    "environment": [
+      {
+        "name": "CLEAN_BUCKET",
+        "value": "${clean_bucket}"
+      },
+      {
+        "name": "OUTPUT_BUCKET",
+        "value": "${output_bucket}"
+      },
+      {
+        "name": "API_URL",
+        "value": "${api_url}"
+      },
+      {
+        "name": "AUTH_URL",
+        "value": "${auth_url}"
+      }
+    ],
+    "mountPoints": [
+      {
+        "containerPath": "/home/consignment-export/export",
+        "sourceVolume": "consignmentexport"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group_name}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Move consignment export task.
   
This moves it over to using the new generic_ecs module.  When I tried to delete keycloak, I was getting a circular dependency problem on the export module and I think this is the way it's set up.
    
This should solve the problem and moves us closer towards having a properly generic terraform-modules.

