### PR TITLE
Set canonical ids which are allowed full access.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -114,12 +114,15 @@ module "upload_file_cloudfront_dirty_s3" {
 }
 
 module "upload_file_cloudfront_logs" {
-  source                     = "./tdr-terraform-modules/s3"
-  project                    = var.project
-  function                   = "upload-cloudfront-logs"
-  common_tags                = local.common_tags
-  access_logs                = false
-  full_control_canonical_ids = [local.logs_delivery_canonical_user_id, data.aws_canonical_user_id.canonical_user.id]
+  source      = "./tdr-terraform-modules/s3"
+  project     = var.project
+  function    = "upload-cloudfront-logs"
+  common_tags = local.common_tags
+  access_logs = false
+  canonical_user_grants = [
+    { id = local.logs_delivery_canonical_user_id, permissions = ["FULL_CONTROL"] },
+    { id = data.aws_canonical_user_id.canonical_user.id, permissions = ["FULL_CONTROL"] }
+  ]
 }
 
 module "cloudfront_upload" {

--- a/root.tf
+++ b/root.tf
@@ -114,11 +114,12 @@ module "upload_file_cloudfront_dirty_s3" {
 }
 
 module "upload_file_cloudfront_logs" {
-  source      = "./tdr-terraform-modules/s3"
-  project     = var.project
-  function    = "upload-cloudfront-logs"
-  common_tags = local.common_tags
-  access_logs = false
+  source                     = "./tdr-terraform-modules/s3"
+  project                    = var.project
+  function                   = "upload-cloudfront-logs"
+  common_tags                = local.common_tags
+  access_logs                = false
+  full_control_canonical_ids = [local.logs_delivery_canonical_user_id, data.aws_canonical_user_id.canonical_user.id]
 }
 
 module "cloudfront_upload" {

--- a/root_data.tf
+++ b/root_data.tf
@@ -25,3 +25,5 @@ resource "random_password" "keycloak_password" {
 resource "random_uuid" "client_secret" {}
 resource "random_uuid" "backend_checks_client_secret" {}
 resource "random_uuid" "reporting_client_secret" {}
+
+data "aws_canonical_user_id" "canonical_user" {}

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -65,4 +65,7 @@ locals {
   keycloak_govuk_notify_api_key_name      = "/${local.environment}/keycloak/govuk_notify/api_key"
   keycloak_govuk_notify_template_id_name  = "/${local.environment}/keycloak/govuk_notify/template_id"
   keycloak_reporting_client_secret_name   = "/${local.environment}/keycloak/reporting_client/secret"
+
+  //Used for allowing full access for Cloudfront logging. More information at https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
+  logs_delivery_canonical_user_id = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
 }


### PR DESCRIPTION
This is a custom ACL grant which allows the aws logs delivery https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
account to access the bucket which allows Cloudfront to write logs to it.

It also allows full access to the bucket owner so we can view and change the logs in it.
