### PR TITLE
Upgrade databases

### DIFF
--- a/modules/consignment-api/database.tf
+++ b/modules/consignment-api/database.tf
@@ -24,7 +24,7 @@ resource "random_string" "snapshot_prefix" {
 resource "aws_rds_cluster" "consignment_api_database" {
   cluster_identifier_prefix           = "consignment-api-db-postgres-${var.environment}"
   engine                              = "aurora-postgresql"
-  engine_version                      = "11.9"
+  engine_version                      = "11.13"
   availability_zones                  = var.database_availability_zones
   database_name                       = var.app_name
   master_username                     = "api_admin"
@@ -60,7 +60,7 @@ resource "aws_rds_cluster_instance" "content_database" {
   identifier_prefix    = "content-db-postgres-instance-${var.environment}"
   cluster_identifier   = aws_rds_cluster.consignment_api_database.id
   engine               = "aurora-postgresql"
-  engine_version       = "11.9"
+  engine_version       = "11.13"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.consignment_api_subnet_group.name
 }


### PR DESCRIPTION
AWS has been upgrading the RDS databases in the background and now the
versions are out of sync with terraform.

This now matches the deployed version.
