### PR TITLE
Add environments for export job.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -224,3 +224,10 @@ module "github_antivirus_server_environment" {
     ACCOUNT_NUMBER = data.aws_caller_identity.current.account_id
   }
 }
+
+module "github_antivirus_server_environment" {
+  source          = "./tdr-terraform-modules/github_environments"
+  environment     = local.environment
+  repository_name = "nationalarchives/tdr-consignment-export"
+  team_slug       = "transfer-digital-records-admins"
+}

--- a/root_github.tf
+++ b/root_github.tf
@@ -225,7 +225,7 @@ module "github_antivirus_server_environment" {
   }
 }
 
-module "github_antivirus_server_environment" {
+module "github_consignment_export_server_environment" {
   source          = "./tdr-terraform-modules/github_environments"
   environment     = local.environment
   repository_name = "nationalarchives/tdr-consignment-export"


### PR DESCRIPTION
These are needed so we can restrict prod and staging deployments which
we're not at the moment.
