### PR TITLE
Add file format roles and secrets.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -354,13 +354,13 @@ module "github_file_format_run_ecs_role" {
 }
 
 module "github_run_file_format_build_policy" {
-  source        = "./tdr-terraform-modules/iam_policy"
-  name          = "TDRGitHubRunFileFormatBuildPolicy${title(local.environment)}"
+  source = "./tdr-terraform-modules/iam_policy"
+  name   = "TDRGitHubRunFileFormatBuildPolicy${title(local.environment)}"
   policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl",
     {
       task_definition_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:task-definition/file-format-build-${local.environment}",
-      cluster_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:cluster/file_format_build_${local.environment}",
-      role_arns = "\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatEcsTaskRole${title(local.environment)}\", \"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(local.environment)}\"" })
+      cluster_arn         = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:cluster/file_format_build_${local.environment}",
+  role_arns = "\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatEcsTaskRole${title(local.environment)}\", \"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(local.environment)}\"" })
 }
 
 module "github_file_format_environment" {

--- a/root_github.tf
+++ b/root_github.tf
@@ -141,7 +141,7 @@ module "github_update_ecs_role" {
 module "github_run_keycloak_update_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRGitHubRunKeycloakUpdatePolicy${title(local.environment)}"
-  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl", { task_definition_arn = module.run_keycloak_update_ecs.task_definition_arn, cluster_arn = module.run_keycloak_update_ecs.cluster_arn, execution_role_arn = module.run_update_keycloak_execution_role.role.arn })
+  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl", { task_definition_arn = module.run_keycloak_update_ecs.task_definition_arn, cluster_arn = module.run_keycloak_update_ecs.cluster_arn, role_arns = "\"${module.run_update_keycloak_execution_role.role.arn}\"" })
 }
 
 module "github_run_keycloak_update_role" {
@@ -356,7 +356,11 @@ module "github_file_format_run_ecs_role" {
 module "github_run_file_format_build_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRGitHubRunFileFormatBuildPolicy${title(local.environment)}"
-  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl", { task_definition_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:task-definition/file-format-build-${local.environment}", cluster_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:cluster/file_format_build_${local.environment}", execution_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(local.environment)}" })
+  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl",
+    {
+      task_definition_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:task-definition/file-format-build-${local.environment}",
+      cluster_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:cluster/file_format_build_${local.environment}",
+      role_arns = "\"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatEcsTaskRole${title(local.environment)}\", \"arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(local.environment)}\"" })
 }
 
 module "github_file_format_environment" {

--- a/root_github.tf
+++ b/root_github.tf
@@ -344,7 +344,7 @@ module "github_download_files_environment" {
 }
 
 module "github_file_format_run_ecs_role" {
-  source = "./tdr-terraform-modules/iam_role"
+  source             = "./tdr-terraform-modules/iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_name = "tdr-*" })
   common_tags        = local.common_tags
   name               = "TDRGithubActionsRunFileFormatECS${title(local.environment)}"

--- a/root_github.tf
+++ b/root_github.tf
@@ -141,7 +141,7 @@ module "github_update_ecs_role" {
 module "github_run_keycloak_update_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRGitHubRunKeycloakUpdatePolicy${title(local.environment)}"
-  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_keycloak_update_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, region = local.region, environment = local.environment })
+  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl", { task_definition_arn = module.run_keycloak_update_ecs.task_definition_arn, cluster_arn = module.run_keycloak_update_ecs.cluster_arn, execution_role_arn = module.run_update_keycloak_execution_role.role.arn })
 }
 
 module "github_run_keycloak_update_role" {
@@ -337,6 +337,32 @@ module "github_download_files_environment" {
   source          = "./tdr-terraform-modules/github_environments"
   environment     = local.environment
   repository_name = "nationalarchives/tdr-download-files"
+  team_slug       = "transfer-digital-records-admins"
+  secrets = {
+    ACCOUNT_NUMBER = data.aws_caller_identity.current.account_id
+  }
+}
+
+module "github_file_format_run_ecs_role" {
+  source = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_name = "tdr-*" })
+  common_tags        = local.common_tags
+  name               = "TDRGithubActionsRunFileFormatECS${title(local.environment)}"
+  policy_attachments = {
+    run_file_format = module.github_run_file_format_build_policy.policy_arn
+  }
+}
+
+module "github_run_file_format_build_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "TDRGitHubRunFileFormatBuildPolicy${title(local.environment)}"
+  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_ecs_policy.json.tpl", { task_definition_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:task-definition/file-format-build-${local.environment}", cluster_arn = "arn:aws:ecs:${local.region}:${data.aws_caller_identity.current.account_id}:cluster/file_format_build_${local.environment}", execution_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRFileFormatECSExecutionRole${title(local.environment)}" })
+}
+
+module "github_file_format_environment" {
+  source          = "./tdr-terraform-modules/github_environments"
+  environment     = local.environment
+  repository_name = "nationalarchives/tdr-file-format"
   team_slug       = "transfer-digital-records-admins"
   secrets = {
     ACCOUNT_NUMBER = data.aws_caller_identity.current.account_id

--- a/templates/iam_policy/github_run_ecs_policy.json.tpl
+++ b/templates/iam_policy/github_run_ecs_policy.json.tpl
@@ -14,7 +14,7 @@
       "Resource": [
         "${cluster_arn}",
         "${task_definition_arn}",
-        "${execution_role_arn}"
+        ${role_arns}
       ]
     },
     {

--- a/templates/iam_policy/github_run_ecs_policy.json.tpl
+++ b/templates/iam_policy/github_run_ecs_policy.json.tpl
@@ -12,9 +12,9 @@
         "iam:PassRole"
       ],
       "Resource": [
-        "arn:aws:ecs:eu-west-2:${account_id}:cluster/keycloak_update_${environment}",
-        "arn:aws:ecs:${region}:${account_id}:task-definition/keycloak-update-${environment}",
-        "arn:aws:iam::${account_id}:role/TDRKeycloakUpdateECSExecutionRole${title(environment)}"
+        "${cluster_arn}",
+        "${task_definition_arn}",
+        "${execution_role_arn}"
       ]
     },
     {


### PR DESCRIPTION
The role needed by the file format run ECS task job is very similar to
the one for running the Keycloak update job so I've refactored the
keycloak one to work with both.
