### PR TITLE
Use IAM auth for Keycloak

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -617,6 +617,7 @@ module "notification_lambda" {
   common_tags                    = local.common_tags
   project                        = "tdr"
   lambda_ecr_scan_notifications  = true
+  kms_key_arn                    = module.encryption_key.kms_key_arn
   event_rule_arns                = []
   sns_topic_arns                 = [module.notifications_topic.sns_arn]
   muted_scan_alerts              = module.global_parameters.muted_ecr_scan_alerts

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -13,7 +13,7 @@ module "keycloak_ecs_execution_policy" {
 module "keycloak_ecs_task_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "KeycloakECSTaskPolicy${title(local.environment)}"
-  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn })
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn, cluster_resource_id = module.keycloak_database.cluster_resource_id })
 }
 
 module "keycloak_execution_role" {
@@ -101,8 +101,6 @@ module "tdr_keycloak_ecs" {
     app_environment                   = local.environment
     aws_region                        = local.region
     url_path                          = module.keycloak_database.db_url_parameter_name
-    username                          = "keycloak_user"
-    password_path                     = local.keycloak_user_password_name
     admin_user_path                   = local.keycloak_admin_user_name
     admin_password_path               = local.keycloak_admin_password_name
     client_secret_path                = local.keycloak_tdr_client_secret_name

--- a/templates/ecs_tasks/keycloak.json.tpl
+++ b/templates/ecs_tasks/keycloak.json.tpl
@@ -9,10 +9,6 @@
         "name": "KC_DB_URL_HOST"
       },
       {
-        "valueFrom": "${password_path}",
-        "name": "KC_DB_PASSWORD"
-      },
-      {
         "valueFrom": "${admin_user_path}",
         "name": "KEYCLOAK_ADMIN"
       },
@@ -69,10 +65,6 @@
       {
         "name" : "KEYCLOAK_IMPORT",
         "value": "/tmp/tdr-realm.json"
-      },
-      {
-        "name": "KC_DB_USERNAME",
-        "value": "${username}"
       },
       {
         "name": "SNS_TOPIC_ARN",


### PR DESCRIPTION
We no longer need the username and password environment variables so
these have been removed.

The database cluster resource ID is now in the task policy so this has
been added.

I've added in the KMS key arn for the notifications lambda. It's not
part of this but it fixes a change I made to terraform modules a while
back.
