### PR TITLE
Remove port 80 from frontend ALB security group.

### DIFF
--- a/modules/transfer-frontend/security.tf
+++ b/modules/transfer-frontend/security.tf
@@ -10,13 +10,6 @@ resource "aws_security_group" "lb" {
     cidr_blocks = var.ip_allowlist
   }
 
-  ingress {
-    protocol    = "tcp"
-    from_port   = 80
-    to_port     = 80
-    cidr_blocks = var.ip_allowlist
-  }
-
   egress {
     protocol    = "-1"
     from_port   = 0


### PR DESCRIPTION
We don't need port 80 open any more as all traffic to the front end is
https so this can be removed and it might help with the problems we have
with the e2e tests.
