### PR TITLE
Add an environment variable for the rotate secrets client.

### DIFF
--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -113,6 +113,7 @@ module "tdr_keycloak_ecs" {
     govuk_notify_api_key_path         = local.keycloak_govuk_notify_api_key_name
     govuk_notify_template_id_path     = local.keycloak_govuk_notify_template_id_name
     reporting_client_secret_path      = local.keycloak_reporting_client_secret_name
+    rotate_client_secrets_client_path = local.keycloak_rotate_secrets_client_secret_name
     sns_topic_arn                     = module.notifications_topic.sns_arn
     keycloak_host                     = "auth.${local.environment_domain}"
   })

--- a/templates/ecs_tasks/keycloak.json.tpl
+++ b/templates/ecs_tasks/keycloak.json.tpl
@@ -45,6 +45,10 @@
         "name": "GOVUK_NOTIFY_TEMPLATE_ID"
       },
       {
+        "valueFrom": "${rotate_client_secrets_client_path}",
+        "name": "ROTATE_CLIENT_SECRETS_CLIENT_SECRET"
+      },
+      {
         "valueFrom": "${reporting_client_secret_path}",
         "name": "REPORTING_CLIENT_SECRET"
       }


### PR DESCRIPTION
This is needed when we start the service, it will read the value of the
secret from this environment variable.
