### PR TITLE
Move API and Keycloak to another subnet.

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_service" "consignment_api_service" {
 
   network_configuration {
     security_groups  = [aws_security_group.ecs_tasks.id]
-    subnets          = var.private_subnets
+    subnets          = var.backend_checks_subnets
     assign_public_ip = false
   }
 

--- a/modules/consignment-api/variables.tf
+++ b/modules/consignment-api/variables.tf
@@ -26,6 +26,8 @@ variable "kms_key_id" {}
 
 variable "private_subnets" {}
 
+variable "backend_checks_subnets" {}
+
 variable "public_subnets" {}
 
 variable "region" {}

--- a/root.tf
+++ b/root.tf
@@ -32,6 +32,7 @@ module "consignment_api" {
   environment                    = local.environment
   environment_full_name          = local.environment_full_name_map[local.environment]
   private_subnets                = module.shared_vpc.private_subnets
+  backend_checks_subnets         = module.backend_checks_efs.private_subnets
   public_subnets                 = module.shared_vpc.public_subnets
   vpc_id                         = module.shared_vpc.vpc_id
   region                         = local.region

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -123,7 +123,7 @@ module "tdr_keycloak_ecs" {
   execution_role               = module.keycloak_execution_role.role.arn
   load_balancer_container_port = 8080
   memory                       = 3072
-  private_subnets              = module.shared_vpc.private_subnets
+  private_subnets              = module.backend_checks_efs.private_subnets
   security_groups              = [module.keycloak_ecs_security_group.security_group_id]
   service_name                 = "keycloak_service_${local.environment}"
   task_family_name             = "keycloak-${local.environment}"


### PR DESCRIPTION
I wanted to move everything to a new larger subnet but it turns out
that is a lot more difficult than it sounds so for now, I've moved the
API and Keycloak ECS tasks to the backend-checks subnet.

This **should** be a temporary change. There is a ticket
https://national-archives.atlassian.net/browse/TDR-2253
to sort this properly.
