### PR TITLE
TDR 2222 single db instance

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -90,7 +90,7 @@ resource "aws_iam_role_policy_attachment" "assume_iam_auth" {
 
 resource "aws_iam_policy" "consignment_api_ecs_task_allow_iam_auth" {
   name   = "TDRConsignmentApiAllowIAMAuthPolicy${title(var.environment)}"
-  policy = templatefile("${path.module}/templates/allow_iam_db_auth.json.tpl", { cluster_id = aws_rds_cluster.consignment_api_database.cluster_resource_id, account_id = data.aws_caller_identity.current.account_id })
+  policy = templatefile("${path.module}/templates/allow_iam_db_auth.json.tpl", { cluster_id = aws_rds_cluster.consignment_api_database.cluster_resource_id, account_id = data.aws_caller_identity.current.account_id, resource_id = var.db_instance_resource_id })
 }
 
 resource "aws_iam_role" "consignment_api_ecs_task" {

--- a/modules/consignment-api/outputs.tf
+++ b/modules/consignment-api/outputs.tf
@@ -30,3 +30,7 @@ output "database_cluster_id" {
 output "database_security_group" {
   value = aws_security_group.database.id
 }
+
+output "ecs_task_security_group_id" {
+  value = aws_security_group.ecs_tasks.id
+}

--- a/modules/consignment-api/templates/allow_iam_db_auth.json.tpl
+++ b/modules/consignment-api/templates/allow_iam_db_auth.json.tpl
@@ -5,7 +5,8 @@
       "Effect": "Allow",
       "Action": "rds-db:connect",
       "Resource": [
-        "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${cluster_id}/consignment_api_user"
+        "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${cluster_id}/consignment_api_user",
+        "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${resource_id}/consignment_api_user"
       ]
     }
   ]

--- a/modules/consignment-api/variables.tf
+++ b/modules/consignment-api/variables.tf
@@ -42,3 +42,5 @@ variable "ip_allowlist" {
 variable "create_users_security_group_id" {
   type = list(string)
 }
+
+variable "db_instance_resource_id" {}

--- a/root.tf
+++ b/root.tf
@@ -40,6 +40,7 @@ module "consignment_api" {
   kms_key_id                     = module.encryption_key.kms_key_arn
   frontend_url                   = module.frontend.frontend_url
   dns_zone_name_trimmed          = local.dns_zone_name_trimmed
+  db_instance_resource_id        = module.consignment_api_database.resource_id
   create_users_security_group_id = flatten([module.create_db_users_lambda.create_users_lambda_security_group_id, module.create_bastion_user_lambda.create_users_lambda_security_group_id])
 }
 

--- a/root.tf
+++ b/root.tf
@@ -881,4 +881,5 @@ module "consignment_api_database" {
   kms_key_id         = module.encryption_key.kms_key_arn
   private_subnets    = module.shared_vpc.private_subnets
   security_group_ids = [module.api_database_security_group.security_group_id]
+  multi_az           = local.environment == "prod"
 }

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -172,6 +172,7 @@ module "keycloak_database_instance" {
   kms_key_id         = module.encryption_key.kms_key_arn
   private_subnets    = module.shared_vpc.private_subnets
   security_group_ids = [module.keycloak_database_security_group.security_group_id]
+  multi_az           = local.environment == "prod"
 }
 
 module "create_keycloak_db_users_lambda_new" {
@@ -199,4 +200,23 @@ module "keycloak_route53" {
   alb_zone_id           = module.keycloak_tdr_alb.alb_zone_id
   create_hosted_zone    = false
   hosted_zone_id        = data.aws_route53_zone.tdr_dns_zone.id
+}
+
+// These three can be deleted once the database move has been done
+resource "aws_ssm_parameter" "db_username_parameter" {
+  name  = "/${local.environment}/keycloak/database/username"
+  type  = "SecureString"
+  value = module.keycloak_database.db_username
+}
+
+resource "aws_ssm_parameter" "db_password_parameter" {
+  name  = "/${local.environment}/keycloak/database/password"
+  type  = "SecureString"
+  value = module.keycloak_database.db_password
+}
+
+resource "aws_ssm_parameter" "db_url_parameter" {
+  name  = "/${local.environment}/keycloak/database/url"
+  type  = "SecureString"
+  value = module.keycloak_database.db_url
 }

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -13,7 +13,7 @@ module "keycloak_ecs_execution_policy" {
 module "keycloak_ecs_task_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "KeycloakECSTaskPolicy${title(local.environment)}"
-  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn, cluster_resource_id = module.keycloak_database.cluster_resource_id })
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn, cluster_resource_id = module.keycloak_database.cluster_resource_id, instance_resource_id = module.keycloak_database_instance.resource_id })
 }
 
 module "keycloak_execution_role" {
@@ -162,6 +162,18 @@ module "keycloak_database" {
   security_group_ids          = [module.keycloak_database_security_group.security_group_id]
 }
 
+module "keycloak_database_instance" {
+  source             = "./tdr-terraform-modules/rds_instance"
+  admin_username     = "keycloak_admin"
+  availability_zone  = local.database_availability_zone
+  common_tags        = local.common_tags
+  database_name      = "keycloak"
+  environment        = local.environment
+  kms_key_id         = module.encryption_key.kms_key_arn
+  private_subnets    = module.shared_vpc.private_subnets
+  security_group_ids = [module.keycloak_database_security_group.security_group_id]
+}
+
 module "create_keycloak_db_users_lambda_new" {
   source                              = "./tdr-terraform-modules/lambda"
   project                             = var.project
@@ -169,9 +181,9 @@ module "create_keycloak_db_users_lambda_new" {
   lambda_create_keycloak_db_users_new = true
   vpc_id                              = module.shared_vpc.vpc_id
   private_subnet_ids                  = module.shared_vpc.private_subnets
-  db_admin_user                       = module.keycloak_database.db_username
-  db_admin_password                   = module.keycloak_database.db_password
-  db_url                              = module.keycloak_database.db_url
+  db_admin_user                       = module.keycloak_database_instance.database_user
+  db_admin_password                   = module.keycloak_database_instance.database_password
+  db_url                              = module.keycloak_database_instance.database_url
   kms_key_arn                         = module.encryption_key.kms_key_arn
   keycloak_password                   = module.keycloak_ssm_parameters.params[local.keycloak_user_password_name].value
   keycloak_database_security_group    = module.keycloak_database_security_group.security_group_id

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -22,6 +22,8 @@ locals {
   )
   database_availability_zones = ["eu-west-2a", "eu-west-2b"]
 
+  database_availability_zone = "eu-west-2a"
+
   region = "eu-west-2"
 
   dns_zone_id = data.aws_route53_zone.tdr_dns_zone.zone_id


### PR DESCRIPTION
Add a new single instance database.

This does the following.

Creates a new single instance DB for keycloak and the API.

Updates the create-users lambdas with the new credentials. We don't use these lambdas normally so this is fine.

Update the task roles to allow access to the new databases.

Adds the existing keycloak master credentials to SSM as for some reason they're not there. These will be deleted after this is all deployed.

Once this is merged and deployed, I'll put in another PR to switch over the API and Keycloak to use these DBs.

This is a draft because it needs https://github.com/nationalarchives/tdr-terraform-modules/pull/204 to be merged so I can update the modules hash