### PR TITLE
Move services to new db

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -22,9 +22,7 @@ data "template_file" "app" {
     app_port        = local.app_port
     app_environment = var.environment
     aws_region      = var.region
-    url_path        = aws_ssm_parameter.database_url.name
-    username_path   = aws_ssm_parameter.database_username.name
-    password_path   = aws_ssm_parameter.database_password.name
+    url_path        = "/${var.environment}/consignmentapi/instance/url"
     auth_url        = var.auth_url
     frontend_url    = var.frontend_url
   }

--- a/modules/consignment-api/ssm.tf
+++ b/modules/consignment-api/ssm.tf
@@ -1,3 +1,4 @@
+//Delete this file once the DB move is complete
 resource "aws_ssm_parameter" "database_url" {
   name  = "/${var.environment}/consignmentapi/database/url"
   type  = "SecureString"

--- a/modules/consignment-api/templates/consignment-api.json.tpl
+++ b/modules/consignment-api/templates/consignment-api.json.tpl
@@ -25,14 +25,6 @@
       {
         "valueFrom": "${url_path}",
         "name": "DB_ADDR"
-      },
-      {
-        "valueFrom": "${username_path}",
-        "name": "DB_USER"
-      },
-      {
-        "valueFrom": "${password_path}",
-        "name": "DB_PASSWORD"
       }
     ],
     "networkMode": "awsvpc",

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -101,7 +101,7 @@ module "tdr_keycloak_ecs" {
     app_port                          = 8080
     app_environment                   = local.environment
     aws_region                        = local.region
-    url_path                          = module.keycloak_database.db_url_parameter_name
+    url_path                          = local.keycloak_db_url
     admin_user_path                   = local.keycloak_admin_user_name
     admin_password_path               = local.keycloak_admin_password_name
     client_secret_path                = local.keycloak_tdr_client_secret_name

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -68,6 +68,7 @@ locals {
   keycloak_govuk_notify_template_id_name     = "/${local.environment}/keycloak/govuk_notify/template_id"
   keycloak_reporting_client_secret_name      = "/${local.environment}/keycloak/reporting_client/secret"
   keycloak_rotate_secrets_client_secret_name = "/${local.environment}/keycloak/rotate_secrets_client/secret"
+  keycloak_db_url                            = "/${local.environment}/keycloak/instance/url"
   slack_bot_token_name                       = "/${local.environment}/slack/bot"
 
   keycloak_reporting_client_id = "tdr-reporting"


### PR DESCRIPTION
This depends on 
https://github.com/nationalarchives/tdr-terraform-environments/pull/249
https://github.com/nationalarchives/tdr-terraform-modules/pull/204

This will update the API and Keycloak ECS tasks to use the new database. This can only be deployed once the new databases have been created and migrated. The steps are defined in [this Jira ticket](https://national-archives.atlassian.net/browse/TDR-2222?focusedCommentId=27261)