### PR TITLE
Update redis version

### DIFF
--- a/modules/transfer-frontend/elasticache.tf
+++ b/modules/transfer-frontend/elasticache.tf
@@ -10,6 +10,7 @@ resource "aws_elasticache_replication_group" "redis_replication_group" {
   port                          = 6379
   security_group_ids            = aws_security_group.redis.*.id
   subnet_group_name             = aws_elasticache_subnet_group.redis_subnet_group.name
+  apply_immediately             = true
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {

--- a/modules/transfer-frontend/elasticache.tf
+++ b/modules/transfer-frontend/elasticache.tf
@@ -5,8 +5,8 @@ resource "aws_elasticache_replication_group" "redis_replication_group" {
   at_rest_encryption_enabled    = true
   engine                        = "redis"
   node_type                     = "cache.t2.micro"
-  parameter_group_name          = "default.redis5.0"
-  engine_version                = "5.0.5"
+  parameter_group_name          = "default.redis6.x"
+  engine_version                = "6.x"
   port                          = 6379
   security_group_ids            = aws_security_group.redis.*.id
   subnet_group_name             = aws_elasticache_subnet_group.redis_subnet_group.name


### PR DESCRIPTION
For versions above 6, you need to set the version as 6x rather than a
specific version.

This is the latest version which AWS offer despite there being a 7.0
available.
