### PR TITLE
Use account specific parameter names.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -440,6 +440,6 @@ module "github_rotate_secrets_environment" {
   repository_name = "nationalarchives/tdr-rotate-keycloak-secrets"
   team_slug       = "transfer-digital-records-admins"
   secrets = {
-    ACCOUNT_NUMBER = data.aws_caller_identity.current.account_id
+    "${upper(local.environment)}_ACCOUNT_NUMBER" = data.aws_caller_identity.current.account_id
   }
 }


### PR DESCRIPTION
The run report action needs to be run by users outside TDR. At the
moment, it's run in an environment which needs approvals.

I want to run it outside the environment but for this we need three
secrets, INTG_ACCOUNT_NUMBER, STAGING_ACCOUNT_NUMBER,
PROD_ACCOUNT_NUMBER which this sets.
