### PR TITLE
Add policy for e2e tests.

### DIFF
--- a/templates/iam_policy/github_e2e_test_secrets_policy.json.tpl
+++ b/templates/iam_policy/github_e2e_test_secrets_policy.json.tpl
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter"
+      ],
+      "Resource": [
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/backend_checks_client/secret",
+        "arn:aws:ssm:eu-west-2:${account_id}:parameter/${environment}/keycloak/user_admin_client/secret"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The e2e tests need to get the secrets from the parameter store as when
they're rotated, the hard coded ones in GitHub secrets don't update.

I've added a policy and role to allow it to get the two secrets it needs
and removed the secrets from the environment.
