### PR TITLE
Add ssm parameter path for Notify key and template id

### DIFF
--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -13,7 +13,7 @@ module "keycloak_ecs_execution_policy" {
 module "keycloak_ecs_task_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "KeycloakECSTaskPolicy${title(local.environment)}"
-  policy_string = templatefile("${path.module}/templates/iam_policy/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn, instance_resource_id = module.keycloak_database_instance.resource_id })
+  policy_string = templatefile("${path.module}/templates/iam_policy/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn, instance_resource_id = module.keycloak_database_instance.resource_id, govuk_notify_api_key_path = local.keycloak_govuk_notify_api_key_name, govuk_notify_template_id_path = local.keycloak_govuk_notify_template_id_name })
 }
 
 module "keycloak_execution_role" {

--- a/templates/ecs_tasks/keycloak.json.tpl
+++ b/templates/ecs_tasks/keycloak.json.tpl
@@ -81,6 +81,14 @@
       {
         "name": "KEYCLOAK_HOST",
         "value": "${keycloak_host}"
+      },
+      {
+        "name": "GOVUK_NOTIFY_API_KEY_PATH",
+        "value": "${govuk_notify_api_key_path}"
+      },
+      {
+        "name": "GOVUK_NOTIFY_TEMPLATE_ID_PATH",
+        "value": "${govuk_notify_template_id_path}"
       }
     ],
     "networkMode": "awsvpc",

--- a/templates/iam_policy/keycloak_ecs_task_role_policy.json.tpl
+++ b/templates/iam_policy/keycloak_ecs_task_role_policy.json.tpl
@@ -14,6 +14,16 @@
         "arn:aws:rds-db:eu-west-2:${account_id}:dbuser:${instance_resource_id}/keycloak_user",
         "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter"
+      ],
+        "Resource": [
+          "arn:aws:ssm:eu-west-2:${account_id}:parameter${govuk_notify_api_key_path}",
+          "arn:aws:ssm:eu-west-2:${account_id}:parameter${govuk_notify_template_id_path}"
+        ]
     }
   ]
 }


### PR DESCRIPTION
Keycloak will retrieve the value of the GOV.UK Notify api key and template id directly from the ssm parameter instead of reading from an environment variable

This will mean any rotation of these values will not require code redeployments

This will support the rotation of the GOV.UK Notify api key

Once the value is being retrieved directly the existing corresponding secrets will be removed as environment variables