### PR TITLE
Only subscribe to TRE SNS topic in intg

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -415,7 +415,7 @@ module "transform_engine_v2_retry_queue" {
   sqs_policy         = "transform_engine_v2_retry"
   visibility_timeout = 180 * 3
   kms_key_id         = module.encryption_key.kms_key_arn
-  sns_topic_arns     = toset([nonsensitive(data.aws_ssm_parameter.transform_engine_v2_tre_out_topic_arn.value)])
+  sns_topic_arns     = toset(local.transform_engine_v2_sqs_topic_subscriptions)
 }
 
 module "api_update_lambda" {

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -75,4 +75,8 @@ locals {
 
   //Used for allowing full access for Cloudfront logging. More information at https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
   logs_delivery_canonical_user_id = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+
+  //Only add subscription for intg as TRE SNS topics for other environments not configured whilst testing. Therefore cannot subscribe to non-existent SNS topics
+  //This should be removed once rest of TRE environments are configured
+  transform_engine_v2_sqs_topic_subscriptions = local.environment == "intg" ? [nonsensitive(data.aws_ssm_parameter.transform_engine_v2_tre_out_topic_arn.value)] : []
 }


### PR DESCRIPTION
TRE SNS topics for other environments not currently configured and therefore cannot subcribe to non-existent SNS topics

When the TRE AWS infrastructure for other environments is in place, this should be updated to allow the subscriptions