### PR TITLE
Split large log files before sending to Cloudwatch

### DIFF
--- a/.github/scripts/logs.py
+++ b/.github/scripts/logs.py
@@ -8,8 +8,17 @@ timestamp = int(time.time()) * 1000
 log_group_name = f"terraform-plan-outputs-{sys.argv[3]}"
 log_stream_name = sys.argv[2]
 
+
 with open(sys.argv[1]) as file:
-    log_event = [{'timestamp': timestamp, 'message': file.read()}]
+    message = file.read()
+    if len(message.encode("utf-8")) > 262144:
+        message_list = message.split("\n")
+        mid_point = len(message_list) // 2
+        first_half = "\n".join(message_list[0: mid_point])
+        second_half = "\n".join(message_list[mid_point:])
+        log_event = [{'timestamp': timestamp, 'message': first_half}, {'timestamp': timestamp, 'message': second_half}]
+    else:
+        log_event = [{'timestamp': timestamp, 'message': message}]
 
 client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
 response = client.put_log_events(logGroupName=log_group_name,

--- a/.github/scripts/logs.py
+++ b/.github/scripts/logs.py
@@ -8,7 +8,6 @@ timestamp = int(time.time()) * 1000
 log_group_name = f"terraform-plan-outputs-{sys.argv[3]}"
 log_stream_name = sys.argv[2]
 
-
 with open(sys.argv[1]) as file:
     message = file.read()
     if len(message.encode("utf-8")) > 262144:


### PR DESCRIPTION
If the plan log is over 262144 bytes, you can't send it in a single log
event. This checks the size and splits it in half if it's too big.

This should keep us going for a while, hopefully until we can split out
tdr-terraform-environments.
