### PR TITLE
Move API gateway definitions and policies.

### DIFF
--- a/templates/api_gateway/backend_checks.json.tpl
+++ b/templates/api_gateway/backend_checks.json.tpl
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "${title}",
+    "version": "1"
+  },
+  "paths": {
+    "/": {
+      "post": {
+        "parameters": [
+          {
+            "name": "consignmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "lambda": []
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "credentials": "${role_arn}",
+          "httpMethod": "POST",
+          "uri": "arn:aws:apigateway:${region}:states:action/StartExecution",
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "requestParameters": {
+            "integration.request.header.Accept-Encoding": "'identity'",
+            "integration.request.header.Content-Type": "'application/x-amz-json-1.1'"
+          },
+          "requestTemplates": {
+            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\"}\",\"stateMachineArn\": \"${state_machine_arn}\"}"
+          },
+          "passthroughBehavior": "when_no_templates",
+          "type": "aws"
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "lambda": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "custom",
+        "x-amazon-apigateway-authorizer": {
+          "authorizerUri": "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda_arn}/invocations",
+          "authorizerResultTtlInSeconds": 0,
+          "type": "token"
+        }
+      }
+    }
+  }
+}

--- a/templates/api_gateway/export_api.json.tpl
+++ b/templates/api_gateway/export_api.json.tpl
@@ -1,0 +1,76 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1",
+    "title": "${title}"
+  },
+  "basePath": "/${environment}",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/export/{consignmentId+}": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "consignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            }
+          }
+        },
+        "security": [
+          {
+            "lambda": []
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "credentials": "${role_arn}",
+          "uri": "arn:aws:apigateway:${region}:states:action/StartExecution",
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "requestParameters": {
+            "integration.request.header.Accept-Encoding": "'identity'",
+            "integration.request.header.Content-Type": "'application/x-amz-json-1.1'"
+          },
+          "requestTemplates": {
+            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\"}\",\"stateMachineArn\": \"${state_machine_arn}\"}"
+          },
+          "passthroughBehavior": "when_no_templates",
+          "httpMethod": "POST",
+          "type": "aws"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "lambda": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "x-amazon-apigateway-authtype": "custom",
+      "x-amazon-apigateway-authorizer": {
+        "authorizerUri": "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda_arn}/invocations",
+        "authorizerResultTtlInSeconds": 0,
+        "type": "token"
+      }
+    }
+  }
+}

--- a/templates/api_gateway/sign_cookies_api.json.tpl
+++ b/templates/api_gateway/sign_cookies_api.json.tpl
@@ -1,0 +1,100 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "0.0.1",
+    "title" : "${title}"
+  },
+  "basePath" : "/${environment}",
+  "schemes" : [ "https" ],
+  "paths" : {
+    "/cookies" : {
+      "get" : {
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "200 response",
+            "schema" : {
+              "$ref" : "#/definitions/Empty"
+            },
+            "headers" : {
+              "Access-Control-Allow-Origin" : {
+                "type" : "string"
+              },
+              "Access-Control-Allow-Credentials" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration" : {
+          "type" : "aws_proxy",
+          "httpMethod" : "POST",
+          "uri" : "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda_arn}/invocations",
+          "responses" : {
+            "default" : {
+              "statusCode" : "200",
+              "responseParameters" : {
+                "method.response.header.Access-Control-Allow-Origin" : "'${upload_cors_urls}'"
+              }
+            }
+          },
+          "passthroughBehavior" : "when_no_match",
+          "contentHandling" : "CONVERT_TO_TEXT"
+        }
+      },
+      "options" : {
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "responses" : {
+          "200" : {
+            "description" : "200 response",
+            "schema" : {
+              "$ref" : "#/definitions/Empty"
+            },
+            "headers" : {
+              "Access-Control-Allow-Origin" : {
+                "type" : "string"
+              },
+              "Access-Control-Allow-Methods" : {
+                "type" : "string"
+              },
+              "Access-Control-Allow-Credentials" : {
+                "type" : "string"
+              },
+              "Access-Control-Allow-Headers" : {
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration" : {
+          "type" : "mock",
+          "responses" : {
+            "default" : {
+              "statusCode" : "200",
+              "responseParameters" : {
+                "method.response.header.Access-Control-Allow-Credentials" : "'true'",
+                "method.response.header.Access-Control-Allow-Methods" : "'GET,OPTIONS'",
+                "method.response.header.Access-Control-Allow-Headers" : "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                "method.response.header.Access-Control-Allow-Origin" : "'${upload_cors_urls}'"
+              },
+              "responseTemplates" : {
+                "application/json" : "#if( $input.params('origin') == 'http://localhost:9000' && $context.stage == 'intg')   #set($context.responseOverride.header.Access-Control-Allow-Origin = 'http://localhost:9000') #end"
+              }
+            }
+          },
+          "requestTemplates" : {
+            "application/json" : "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior" : "when_no_match"
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "Empty" : {
+      "type" : "object",
+      "title" : "Empty Schema"
+    }
+  }
+}

--- a/templates/iam_policy/assume_role_policy.json.tpl
+++ b/templates/iam_policy/assume_role_policy.json.tpl
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "${service}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/templates/iam_policy/export_api_policy.json.tpl
+++ b/templates/iam_policy/export_api_policy.json.tpl
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:*:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "states:StartExecution"
+      ],
+      "Resource": [
+        "${state_machine_arn}"
+      ]
+    }
+  ]
+}

--- a/templates/iam_policy/sign_cookies_api_policy.json.tpl
+++ b/templates/iam_policy/sign_cookies_api_policy.json.tpl
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:*:*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
These have been moved from tdr-terraform-modules to make the module less
TDR specific and the call to the module has been updated to use the new
modules. This will have to be deployed in tandem with https://github.com/nationalarchives/tdr-terraform-modules/pull/236

If I move the resources using `terraform state mv` this shouldn't need
downtime.
