### PR TITLE
Remove security audit IAM user group

### DIFF
--- a/root_locals.tf
+++ b/root_locals.tf
@@ -84,7 +84,7 @@ locals {
   transform_engine_v2_sqs_topic_subscriptions = local.environment == "intg" ? [nonsensitive(data.aws_ssm_parameter.transform_engine_v2_tre_out_topic_arn.value)] : []
 
   //Set to true to create security audit IAM user group
-  security_audit = local.environment == false
+  security_audit = false
 
   //Feature access blocks
   block_feature_closure_metadata     = local.environment == "prod"

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -83,8 +83,8 @@ locals {
   //This should be removed once rest of TRE environments are configured
   transform_engine_v2_sqs_topic_subscriptions = local.environment == "intg" ? [nonsensitive(data.aws_ssm_parameter.transform_engine_v2_tre_out_topic_arn.value)] : []
 
-  //Don't run testing on prod
-  security_audit = local.environment == "prod" ? false : true
+  //Set to true to create security audit IAM user group
+  security_audit = local.environment == false
 
   //Feature access blocks
   block_feature_closure_metadata     = local.environment == "prod"


### PR DESCRIPTION
IAM user group is no longer needed as pen testing complete

Leaving an unsed IAM user group is considered a moderate secruity risk in itself