### PR TITLE
Add new E2E test policy.

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -120,6 +120,22 @@ module "github_update_waf_and_security_groups_role" {
   }
 }
 
+module "github_run_e2e_tests_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "TDRGithubActionsRunE2ETestsPolicy${title(local.environment)}"
+  policy_string = templatefile("${path.module}/templates/iam_policy/github_run_e2e_tests_policy.json.tpl", { environment = local.environment })
+}
+
+module "github_run_e2e_tests_role" {
+  source             = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id })
+  common_tags        = local.common_tags
+  name               = "TDRGithubActionsRunE2ETestsRole${title(local.environment)}"
+  policy_attachments = {
+    run_tests_policy = module.github_run_e2e_tests_policy.policy_arn
+  }
+}
+
 module "github_update_ecs_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRGitHubECSUpdatePolicy${title(local.environment)}"

--- a/templates/iam_policy/github_run_e2e_tests_policy.json.tpl
+++ b/templates/iam_policy/github_run_e2e_tests_policy.json.tpl
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::tdr-consignment-export-${environment}/*",
+        "arn:aws:s3:::tdr-consignment-export-judgment-${environment}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::tdr-upload-files-${environment}/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For some reason we were assuming a role in GitHub actions in the
management account and then assuming a role into the integration or
staging accounts within the tests. This was necessary when we were
running it in Jenkins but it isn't any longer.

This is a new role which the e2e tests will assume in the actions
runner.
