### PR TITLE
Increase api update lambda timeout

### DIFF
--- a/root_backend_checks.tf
+++ b/root_backend_checks.tf
@@ -98,6 +98,7 @@ module "api_update_v2" {
   function_name        = local.api_update_v2_function_name
   handler              = "uk.gov.nationalarchives.api.update.Lambda::update"
   reserved_concurrency = -1
+  timeout_seconds      = 60
   policies = {
     "TDRAPIUpdateV2LambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/lambda_policy.json.tpl", {
       function_name  = local.api_update_v2_function_name,


### PR DESCRIPTION
Lambda timeout was set to default to 15secs and was timing out for large consignments

Increase to 60secs to bring into line with other backend checks lambdas