### PR TITLE
TDR-3129 - Add otel_service_name environment variable

### DIFF
--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -29,6 +29,7 @@ data "template_file" "app" {
     alb_ip_a               = var.public_subnet_ranges[0]
     alb_ip_b               = var.public_subnet_ranges[1]
     auth_url               = var.auth_url
+    otel_service_name      = var.otel_service_name
   }
 }
 

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -63,6 +63,10 @@
       {
         "name": "AUTH_URL",
         "value": "${auth_url}"
+      },
+      {
+        "name": "OTEL_SERVICE_NAME",
+        "value": "${otel_service_name}"
       }
     ],
     "networkMode": "awsvpc",

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -37,6 +37,8 @@ variable "export_api_url" {}
 
 variable "backend_checks_api_url" {}
 
+variable "otel_service_name" {}
+
 variable "alb_id" {}
 
 variable "public_subnet_ranges" {

--- a/root.tf
+++ b/root.tf
@@ -67,6 +67,7 @@ module "frontend" {
   backend_checks_api_url = module.backend_checks_api.api_url
   alb_id                 = module.frontend_alb.alb_id
   public_subnet_ranges   = module.shared_vpc.public_subnet_ranges
+  otel_service_name      = "frontend-${local.environment}"
 }
 
 module "alb_logs_s3" {


### PR DESCRIPTION
Currently the frontend ecs node appears as `unknown_service:java` on the xray ui. This adds a new environment variable `otel_service_name` to the frontend ecs task. So that it appears as shown here:

![image](https://user-images.githubusercontent.com/9700622/235952043-ee855d51-7dce-46d0-8833-6a0d6f0c3779.png)
