### PR TITLE
TDR-3295 Add 'ecs-task-events' log group permissions to frontend_ecs_execution role

### DIFF
--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -157,7 +157,8 @@ data "aws_iam_policy_document" "frontend_ecs_execution" {
       "arn:aws:ecr:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:repository/transfer-frontend",
       "${aws_cloudwatch_log_group.aws-otel-collector.arn}:*",
       "arn:aws:ecr:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:repository/aws-otel-collector",
-      "arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/application/metrics:log-stream:otel-stream-*"
+      "arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/application/metrics:log-stream:otel-stream-*",
+      "arn:aws:logs:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:log-group:/aws/events/ecs-task-events-${var.environment}:*"
     ]
   }
   statement {

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "frontend_ecs_execution" {
       "${aws_cloudwatch_log_group.aws-otel-collector.arn}:*",
       "arn:aws:ecr:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:repository/aws-otel-collector",
       "arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/ecs/application/metrics:log-stream:otel-stream-*",
-      "arn:aws:logs:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:log-group:/aws/events/ecs-task-events-${var.environment}:*"
+      "arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:/aws/events/ecs-task-events-${var.environment}:*"
     ]
   }
   statement {


### PR DESCRIPTION
Allow logs to be inserted to the 'ecs-task-events' log group