### PR TITLE
Local to set the correct tre environment name

### DIFF
--- a/root_locals.tf
+++ b/root_locals.tf
@@ -104,6 +104,8 @@ locals {
   url_path              = "/${local.environment}/consignmentapi/instance/url"
   tmp_directory         = "/tmp"
   consignment_user_name = "consignment_api_user"
+  //tre has used different naming conventions for its environment names
+  tre_environment       = local.environment == "intg" ? "int" : local.environment
 
   //feature access blocks
   block_http4s                 = local.environment == "prod" ? true : false

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -105,7 +105,7 @@ locals {
   tmp_directory         = "/tmp"
   consignment_user_name = "consignment_api_user"
   //tre has used different naming conventions for its environment names
-  tre_environment       = local.environment == "intg" ? "int" : local.environment
+  tre_environment = local.environment == "intg" ? "int" : local.environment
 
   //feature access blocks
   block_http4s                 = local.environment == "prod" ? true : false


### PR DESCRIPTION
TRE naming of environments does not following TDR's naming convention

Add local to convert the TDR environment name to the correct TRE environment name