### PR TITLE
Cipher text encrytion requires string value

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -520,7 +520,7 @@ module "notification_lambda" {
   muted_scan_alerts              = module.global_parameters.muted_ecr_scan_alerts
   judgment_export_s3_bucket_name = module.export_bucket_judgment.s3_bucket_name
   standard_export_s3_bucket_name = module.export_bucket.s3_bucket_name
-  da_event_bus_arn               = "placeholder_value"
+  da_event_bus_arn               = local.da_event_bus_arn
 }
 
 module "tdr_public_nacl" {

--- a/root.tf
+++ b/root.tf
@@ -520,6 +520,7 @@ module "notification_lambda" {
   muted_scan_alerts              = module.global_parameters.muted_ecr_scan_alerts
   judgment_export_s3_bucket_name = module.export_bucket_judgment.s3_bucket_name
   standard_export_s3_bucket_name = module.export_bucket.s3_bucket_name
+  da_event_bus_arn               = "placeholder_value"
 }
 
 module "tdr_public_nacl" {


### PR DESCRIPTION
Until actual event bus arn available use a placeholder value for Terraform to apply successfully