### PR TITLE
Encrypt standard export bucket with KMS key

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -487,10 +487,14 @@ module "export_step_function" {
 }
 
 module "export_bucket" {
-  source      = "./tdr-terraform-modules/s3"
-  project     = var.project
-  function    = "consignment-export"
-  common_tags = local.common_tags
+  source             = "./tdr-terraform-modules/s3"
+  project            = var.project
+  function           = "consignment-export"
+  common_tags        = local.common_tags
+  kms_key_id         = local.s3_encryption_key_arn
+  bucket_key_enabled = local.bucket_key_enabled
+  tre_role_arn       = local.tre_export_role_arn
+  bucket_policy      = "export_bucket"
 }
 
 module "export_bucket_judgment" {


### PR DESCRIPTION
Requires PRs:

- https://github.com/nationalarchives/tdr-terraform-environments/pull/378
- https://github.com/nationalarchives/tdr-terraform-environments/pull/380

In addition requires AWS SSO TDR-Export group permissions updated to give access to the KMS key used to encrypt the s3 export buckets.