### PR TITLE
Pass s3 export bucket access roles as array

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -489,25 +489,25 @@ module "export_step_function" {
 }
 
 module "export_bucket" {
-  source             = "./tdr-terraform-modules/s3"
-  project            = var.project
-  function           = "consignment-export"
-  common_tags        = local.common_tags
-  kms_key_id         = local.s3_encryption_key_arn
-  bucket_key_enabled = local.bucket_key_enabled
-  tre_role_arn       = local.tre_export_role_arn
-  bucket_policy      = "export_bucket"
+  source                = "./tdr-terraform-modules/s3"
+  project               = var.project
+  function              = "consignment-export"
+  common_tags           = local.common_tags
+  kms_key_id            = local.s3_encryption_key_arn
+  bucket_key_enabled    = local.bucket_key_enabled
+  read_access_role_arns = local.standard_export_bucket_read_access_roles
+  bucket_policy         = "export_bucket"
 }
 
 module "export_bucket_judgment" {
-  source             = "./tdr-terraform-modules/s3"
-  project            = var.project
-  function           = "consignment-export-judgment"
-  common_tags        = local.common_tags
-  kms_key_id         = local.s3_encryption_key_arn
-  bucket_key_enabled = local.bucket_key_enabled
-  tre_role_arn       = local.tre_export_role_arn
-  bucket_policy      = "export_bucket"
+  source                = "./tdr-terraform-modules/s3"
+  project               = var.project
+  function              = "consignment-export-judgment"
+  common_tags           = local.common_tags
+  kms_key_id            = local.s3_encryption_key_arn
+  bucket_key_enabled    = local.bucket_key_enabled
+  read_access_role_arns = local.judgment_export_bucket_read_access_role
+  bucket_policy         = "export_bucket"
 }
 
 module "notifications_topic" {

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -113,6 +113,9 @@ locals {
   bucket_key_enabled    = local.environment == "prod" ? false : true
   tre_export_role_arn   = module.tre_configuration.terraform_config[local.tre_environment]["s3_export_bucket_reader_arn"]
 
+  standard_export_bucket_read_access_roles = [local.tre_export_role_arn]
+  judgment_export_bucket_read_access_role  = [local.tre_export_role_arn]
+
   // event bus hosted on tre environments
   da_event_bus_arn     = module.tre_configuration.terraform_config[local.tre_environment]["da_eventbus"]
   da_event_bus_kms_key = module.tre_configuration.terraform_config["${local.tre_environment}_da_eventbus_kms_arn"]


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-terraform-modules/pull/268

Further IAM roles will need access to the s3 export buckets

Pass these roles as an array instead of individually