### PR TITLE
Increase cpu for 'staging' and 'prod' environments

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -1,6 +1,9 @@
 locals {
   app_port           = 8080
   ecr_account_number = var.environment == "sbox" ? data.aws_caller_identity.current.account_id : data.aws_ssm_parameter.mgmt_account_number.value
+  cpu                = var.environment == "intg" ? "512" : "1024"
+  memory             = var.environment == "intg" ? "1024" : "2048"
+
 }
 
 resource "aws_ecs_cluster" "consignment_api_ecs" {
@@ -38,8 +41,8 @@ resource "aws_ecs_task_definition" "consignment_api_task" {
   execution_role_arn       = aws_iam_role.consignment_api_ecs_execution.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = local.cpu
+  memory                   = local.memory
   container_definitions    = data.template_file.app.rendered
   task_role_arn            = aws_iam_role.consignment_api_ecs_task.arn
 


### PR DESCRIPTION
As part of the load testing for TDR an initial recommendation would be to increase the CPU for the Consignment API ECS task.

Increasing CPU to 1024 (1 vCPU) will potentially give the following advantages:
- Improve the overall stability of TDR when a transfer with a large number of files (1000+) is being processed with other transfers occurring in parallel. Not increasing the CPU is likely to see a degradation to judgment users when larger transfers are happening
- Improve the UI responsiveness for a transfer with a large number of files, eg user adding additional metadata etc. Some of the UI improvements and additional features being added (eg adding references) are likely to put further pressure on the API making this increase more likely to be needed regardless of trying to increase the number of files TDR can handle. Increase the maximum number of files per transfer TDR can take. This is of secondary benefit compared to the above points.

See details here: https://national-archives.atlassian.net/browse/TDR-726