### PR TITLE
Feature Access Block for shared Keycloak pages

### DIFF
--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -116,6 +116,7 @@ module "tdr_keycloak_ecs" {
     rotate_client_secrets_client_path = local.keycloak_rotate_secrets_client_secret_name
     sns_topic_arn                     = module.notifications_topic.sns_arn
     keycloak_host                     = "auth.${local.environment_domain}"
+    block_shared_pages                = local.block_shared_keycloak_pages
   })
   container_name               = "keycloak"
   cpu                          = 1024

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -125,4 +125,5 @@ locals {
   //feature access blocks
   block_assign_file_references = local.environment == "intg" ? false : true
   block_validation_library     = local.environment == "intg" ? false : true
+  block_shared_keycloak_pages  = local.environment == "intg" ? false : true
 }

--- a/templates/ecs_tasks/keycloak.json.tpl
+++ b/templates/ecs_tasks/keycloak.json.tpl
@@ -89,6 +89,10 @@
       {
         "name": "GOVUK_NOTIFY_TEMPLATE_ID_PATH",
         "value": "${govuk_notify_template_id_path}"
+      },
+      {
+        "name": "BLOCK_SHARED_PAGES",
+        "value": "${block_shared_pages}"
       }
     ],
     "networkMode": "awsvpc",


### PR DESCRIPTION
Keycloak login page designs are to be changes so they can be shared between multiple services (TDR / AYR)

Use FAB to ensure new page designs are not released before completed