### PR TITLE
Set ECS desired task count to '0' for Christmas downtime

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "consignment_api_service" {
   name                              = "${var.app_name}_service_${var.environment}"
   cluster                           = aws_ecs_cluster.consignment_api_ecs.id
   task_definition                   = aws_ecs_task_definition.consignment_api_task.arn
-  desired_count                     = 1
+  desired_count                     = var.service_tasks_desired_count
   launch_type                       = "FARGATE"
   health_check_grace_period_seconds = "360"
 

--- a/modules/consignment-api/variables.tf
+++ b/modules/consignment-api/variables.tf
@@ -54,3 +54,9 @@ variable "db_instance_resource_id" {}
 variable "block_assign_file_references" {}
 
 variable "block_validation_library" {}
+
+variable "service_tasks_desired_count" {
+  description = "Number of desired running tasks for the service"
+  type        = number
+  default     = 1
+}

--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_service" "frontend_service" {
   name                              = "${var.app_name}_service_${var.environment}"
   cluster                           = aws_ecs_cluster.frontend_ecs.id
   task_definition                   = aws_ecs_task_definition.frontend_task.arn
-  desired_count                     = 1
+  desired_count                     = var.service_tasks_desired_count
   launch_type                       = "FARGATE"
   health_check_grace_period_seconds = "360"
 

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -45,3 +45,9 @@ variable "public_subnet_ranges" {
   type = list(string)
 }
 variable "block_validation_library" {}
+
+variable "service_tasks_desired_count" {
+  description = "Number of desired running tasks for the service"
+  type        = number
+  default     = 1
+}

--- a/root.tf
+++ b/root.tf
@@ -62,32 +62,34 @@ module "consignment_api" {
   da_reference_generator_url     = local.da_reference_generator_url
   da_reference_generator_limit   = local.da_reference_generator_limit
   block_validation_library       = local.block_validation_library
+  service_tasks_desired_count    = local.ecs_service_tasks_desired_count
 }
 
 module "frontend" {
-  app_name                 = "frontend"
-  source                   = "./modules/transfer-frontend"
-  alb_dns_name             = module.frontend_alb.alb_dns_name
-  alb_target_group_arn     = module.frontend_alb.alb_target_group_arn
-  alb_zone_id              = module.frontend_alb.alb_zone_id
-  dns_zone_id              = local.dns_zone_id
-  environment              = local.environment
-  environment_full_name    = local.environment_full_name_map[local.environment]
-  common_tags              = local.common_tags
-  ip_allowlist             = local.environment == "intg" ? local.ip_allowlist : ["0.0.0.0/0"]
-  region                   = local.region
-  vpc_id                   = module.shared_vpc.vpc_id
-  public_subnets           = module.shared_vpc.public_subnets
-  private_subnets          = module.shared_vpc.private_subnets
-  dns_zone_name_trimmed    = local.dns_zone_name_trimmed
-  auth_url                 = local.keycloak_auth_url
-  client_secret_path       = module.keycloak_ssm_parameters.params[local.keycloak_tdr_client_secret_name].name
-  export_api_url           = module.export_api.api_url
-  backend_checks_api_url   = module.backend_checks_api.api_url
-  alb_id                   = module.frontend_alb.alb_id
-  public_subnet_ranges     = module.shared_vpc.public_subnet_ranges
-  otel_service_name        = "frontend-${local.environment}"
-  block_validation_library = local.block_validation_library
+  app_name                    = "frontend"
+  source                      = "./modules/transfer-frontend"
+  alb_dns_name                = module.frontend_alb.alb_dns_name
+  alb_target_group_arn        = module.frontend_alb.alb_target_group_arn
+  alb_zone_id                 = module.frontend_alb.alb_zone_id
+  dns_zone_id                 = local.dns_zone_id
+  environment                 = local.environment
+  environment_full_name       = local.environment_full_name_map[local.environment]
+  common_tags                 = local.common_tags
+  ip_allowlist                = local.environment == "intg" ? local.ip_allowlist : ["0.0.0.0/0"]
+  region                      = local.region
+  vpc_id                      = module.shared_vpc.vpc_id
+  public_subnets              = module.shared_vpc.public_subnets
+  private_subnets             = module.shared_vpc.private_subnets
+  dns_zone_name_trimmed       = local.dns_zone_name_trimmed
+  auth_url                    = local.keycloak_auth_url
+  client_secret_path          = module.keycloak_ssm_parameters.params[local.keycloak_tdr_client_secret_name].name
+  export_api_url              = module.export_api.api_url
+  backend_checks_api_url      = module.backend_checks_api.api_url
+  alb_id                      = module.frontend_alb.alb_id
+  public_subnet_ranges        = module.shared_vpc.public_subnet_ranges
+  otel_service_name           = "frontend-${local.environment}"
+  block_validation_library    = local.block_validation_library
+  service_tasks_desired_count = local.ecs_service_tasks_desired_count
 }
 
 module "alb_logs_s3" {

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -120,6 +120,7 @@ module "tdr_keycloak_ecs" {
   })
   container_name               = "keycloak"
   cpu                          = 1024
+  desired_count                = local.ecs_service_tasks_desired_count
   environment                  = local.environment
   execution_role               = module.keycloak_execution_role.role.arn
   load_balancer_container_port = 8080

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -105,6 +105,8 @@ locals {
   tmp_directory         = "/tmp"
   consignment_user_name = "consignment_api_user"
 
+  ecs_service_tasks_desired_count = local.environment == "intg" ? 1 : 0
+
   //tre has used different naming conventions for its environment names
   tre_environment     = local.environment == "intg" ? "int" : local.environment
   tre_export_role_arn = module.tre_configuration.terraform_config[local.tre_environment]["s3_export_bucket_reader_arn"]


### PR DESCRIPTION
Setting the desired count to '0' will effectively stop the TDR main application containers from running

This will prevent any access to the application