### PR TITLE
Fix empty string being passed as role Arn on prod

### DIFF
--- a/root_encryption.tf
+++ b/root_encryption.tf
@@ -1,3 +1,7 @@
+locals {
+  e2e_testing_role_arns = local.environment == "prod" ? [] : [module.tdr_configuration.terraform_config[local.environment]["e2e_testing_role_arn"]]
+}
+
 module "s3_external_kms_key" {
   source   = "./da-terraform-modules/kms"
   key_name = "tdr-s3-external-kms-${local.environment}"
@@ -21,8 +25,7 @@ module "s3_internal_kms_key" {
       module.yara_av_v2.lambda_role_arn,
       module.file_upload_data.lambda_role_arn,
       module.consignment_export_task_role.role.arn,
-      local.e2e_testing_role_arn
-    ], local.aws_sso_internal_bucket_access_roles)
+    ], local.aws_sso_internal_bucket_access_roles, local.e2e_testing_role_arns)
     ci_roles      = [local.assume_role]
     service_names = ["cloudwatch"]
   }

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -133,6 +133,4 @@ locals {
   //feature access blocks
   block_shared_keycloak_pages = local.environment == "intg" ? false : true
   block_draft_metadata_upload = local.environment == "intg" ? false : true
-
-  e2e_testing_role_arn = module.tdr_configuration.terraform_config[local.environment]["e2e_testing_role_arn"]
 }


### PR DESCRIPTION
Prod has no IAM role for e2e tests which is defined as an empty string in the configurations

Trying to pass an empty string as an arn to an IAM policy causes an error

Refactor e2e test role local to array and use empty array for prod