### PR TITLE
TDRD 88- Evolved draft metadata step function and related infrastructure

### DIFF
--- a/root_backend_checks.tf
+++ b/root_backend_checks.tf
@@ -256,6 +256,7 @@ module "yara_av_v2" {
       dirty_bucket      = local.upload_files_cloudfront_dirty_bucket_name
       clean_bucket      = module.upload_bucket.s3_bucket_name
       quarantine_bucket = module.upload_bucket_quarantine.s3_bucket_name
+      metadata_bucket   = local.draft_metadata_s3_bucket_name
       decryption_keys   = jsonencode([module.s3_upload_kms_key.kms_key_arn])
       encryption_keys   = jsonencode([module.s3_internal_kms_key.kms_key_arn])
     })

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -166,7 +166,7 @@ resource "aws_iam_policy" "api_invoke_policy" {
           "secretsmanager:GetSecretValue",
           "secretsmanager:DescribeSecret"
         ]
-        Resource = "arn:aws:secretsmanager:*:*:secret:events!connection/*"
+        Resource = "arn:aws:secretsmanager:${local.region}:${var.tdr_account_number}:secret:events!connection/*"
       }
     ]
   })

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -69,8 +69,8 @@ resource "aws_iam_role" "draft_metadata_api_gateway_execution_role" {
       Version = "2012-10-17",
       Statement = [
         {
-          Effect = "Allow",
-          Action = "states:StartExecution",
+          Effect   = "Allow",
+          Action   = "states:StartExecution",
           Resource = module.draft_metadata_checks.step_function_arn
         }
       ]
@@ -137,40 +137,40 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
 }
 
 resource "aws_iam_policy" "api_invoke_policy" {
-    name = "TDRAPIInvokePolicy${title(local.environment)}"
+  name = "TDRAPIInvokePolicy${title(local.environment)}"
 
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect    = "Allow"
-          Action    = "states:InvokeHTTPEndpoint"
-          Resource  = module.draft_metadata_checks.step_function_arn
-          Condition = {
-            StringEquals = {
-              "states:HTTPMethod" = "POST"
-            }
-            StringLike = {
-              "states:HTTPEndpoint" = "${module.consignment_api.api_url}/*"
-            }
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "states:InvokeHTTPEndpoint"
+        Resource = module.draft_metadata_checks.step_function_arn
+        Condition = {
+          StringEquals = {
+            "states:HTTPMethod" = "POST"
           }
-        },
-        {
-          Effect  = "Allow"
-          Action  = "events:RetrieveConnectionCredentials"
-          Resource = aws_cloudwatch_event_connection.consignment_api_connection.arn
-        },
-        {
-          Effect  = "Allow"
-          Action  = [
-            "secretsmanager:GetSecretValue",
-            "secretsmanager:DescribeSecret"
-          ]
-          Resource = "arn:aws:secretsmanager:*:*:secret:events!connection/*"
+          StringLike = {
+            "states:HTTPEndpoint" = "${module.consignment_api.api_url}/*"
+          }
         }
-      ]
-    })
-  }
+      },
+      {
+        Effect   = "Allow"
+        Action   = "events:RetrieveConnectionCredentials"
+        Resource = aws_cloudwatch_event_connection.consignment_api_connection.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = "arn:aws:secretsmanager:*:*:secret:events!connection/*"
+      }
+    ]
+  })
+}
 
 module "draft_metadata_checks" {
   source             = "./da-terraform-modules/sfn"
@@ -209,16 +209,16 @@ module "draft_metadata_checks" {
           ],
           "Default" : "RunValidateMetadataLambda"
         },
-        "PrepareVirusDetectedQueryParams": {
+        "PrepareVirusDetectedQueryParams" : {
           "Type" : "Pass",
           "ResultPath" : "$.statusUpdate",
           "Parameters" : {
-            "query": "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!) { updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput) }",
-            "variables": {
-              "updateConsignmentStatusInput": {
-                "consignmentId.$": "$.consignmentId",
-                "statusType": "DraftMetadata",
-                "statusValue": "Failed"
+            "query" : "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!) { updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput) }",
+            "variables" : {
+              "updateConsignmentStatusInput" : {
+                "consignmentId.$" : "$.consignmentId",
+                "statusType" : "DraftMetadata",
+                "statusValue" : "Failed"
               }
             }
           },
@@ -253,6 +253,6 @@ module "draft_metadata_checks" {
   )
   step_function_role_policy_attachments = {
     "lambda-policy" : aws_iam_policy.draft_metadata_checks_policy.arn,
-    "api-invoke-policy": aws_iam_policy.api_invoke_policy.arn
+    "api-invoke-policy" : aws_iam_policy.api_invoke_policy.arn
   }
 }

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -57,7 +57,7 @@ data "aws_ssm_parameter" "backend_checks_keycloak_secret" {
   name = local.keycloak_backend_checks_secret_name
 }
 
-resource "cloudwatch_event_connection" "consignment_api_connection" {
+resource "aws_cloudwatch_event_connection" "consignment_api_connection" {
   name               = "TDRConsignmentAPIConnection${title(local.environment)}"
   authorization_type = "OAUTH_CLIENT_CREDENTIALS"
 
@@ -131,7 +131,7 @@ module "draft_metadata_checks" {
           "Parameters" : {
             "ApiEndpoint" : "${module.consignment_api.api_url}/consignment",
             "Method" : "POST",
-            "Authentication" : aws_events_connection.consignment_api_connection
+            "Authentication" : aws_cloudwatch_event_connection.consignment_api_connection
             "Headers" : {
               "Content-Type" : "application/json"
             },

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -143,7 +143,6 @@ resource "aws_iam_policy" "api_invoke_policy" {
       Version = "2012-10-17"
       Statement = [
         {
-          Sid       = "Statement1"
           Effect    = "Allow"
           Action    = "states:InvokeHTTPEndpoint"
           Resource  = module.draft_metadata_checks.step_function_arn
@@ -157,13 +156,11 @@ resource "aws_iam_policy" "api_invoke_policy" {
           }
         },
         {
-          Sid     = "Statement2"
           Effect  = "Allow"
           Action  = "events:RetrieveConnectionCredentials"
           Resource = aws_cloudwatch_event_connection.consignment_api_connection.arn
         },
         {
-          Sid     = "Statement3"
           Effect  = "Allow"
           Action  = [
             "secretsmanager:GetSecretValue",

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -73,8 +73,8 @@ resource "aws_cloudwatch_event_connection" "consignment_api_connection" {
 
       oauth_http_parameters {
         body {
-          key   = "grant_type"
-          value = "client_credentials"
+          key             = "grant_type"
+          value           = "client_credentials"
           is_value_secret = false
         }
       }

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -88,7 +88,8 @@ module "draft_metadata_checks" {
           "Resource": module.yara_av_v2.lambda_arn
           "Parameters": {
             "consignmentId.$": "$.consignmentId",
-            "checkType.$": "metadata"
+            "fileId.$": "draft-metadata.csv",
+            "scanType.$": "metadata"
           },
           "Next": "CheckAntivirusResults"
         },

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -57,7 +57,7 @@ data "aws_ssm_parameter" "backend_checks_keycloak_secret" {
   name = local.keycloak_backend_checks_secret_name
 }
 
-resource "aws_events_connection" "consignment_api_connection" {
+resource "cloudwatch_event_connection" "consignment_api_connection" {
   name               = "TDRConsignmentAPIConnection${title(local.environment)}"
   authorization_type = "OAUTH_CLIENT_CREDENTIALS"
 

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -54,7 +54,7 @@ module "draft_metadata_bucket" {
 }
 
 data "aws_ssm_parameter" "backend_checks_keycloak_secret" {
-  name = local.keycloak_backend_checks_secret_name
+  name            = local.keycloak_backend_checks_secret_name
   with_decryption = true
 }
 
@@ -134,7 +134,7 @@ module "draft_metadata_checks" {
             "ApiEndpoint" : "${module.consignment_api.api_url}/consignment",
             "Method" : "POST",
             "Authentication" : {
-              "ConnectionArn": aws_cloudwatch_event_connection.consignment_api_connection.arn
+              "ConnectionArn" : aws_cloudwatch_event_connection.consignment_api_connection.arn
             },
             "Headers" : {
               "Content-Type" : "application/json"

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -69,12 +69,13 @@ resource "aws_cloudwatch_event_connection" "consignment_api_connection" {
       }
 
       authorization_endpoint = local.keycloak_auth_url
-      http_method            = "POST"
+      http_method            = "GET"
 
       oauth_http_parameters {
-        body_parameters {
+        body {
           key   = "grant_type"
           value = "client_credentials"
+          is_value_secret = false
         }
       }
     }

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -121,19 +121,20 @@ module "draft_metadata_checks" {
             "fileId" : "draft-metadata.csv",
             "scanType" : "metadata"
           },
+          "ResultPath" : "$.output",
           "Next" : "CheckAntivirusResults"
         },
         "CheckAntivirusResults" : {
           "Type" : "Choice",
           "Choices" : [
             {
-              "Variable" : "$.result",
+              "Variable" : "$.output.antivirus.result",
               "StringEquals" : "",
               "Next" : "RunValidateMetadataLambda"
             },
             {
               "Not" : {
-                "Variable" : "$.result",
+                "Variable" : "$.output.antivirus.result",
                 "StringEquals" : ""
               },
               "Next" : "PrepareVirusDetectedQueryParams"

--- a/templates/api_gateway/draft_metadata.json.tpl
+++ b/templates/api_gateway/draft_metadata.json.tpl
@@ -1,8 +1,9 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "version": "1",
-    "title": "${title}"
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "API Gateway for Draft Metadata validation",
+    "version" : "0.0.1",
+    "title" : "${title}"
   },
   "basePath" : "/${environment}",
   "schemes" : [ "https" ],

--- a/templates/api_gateway/draft_metadata.json.tpl
+++ b/templates/api_gateway/draft_metadata.json.tpl
@@ -1,9 +1,8 @@
 {
-  "swagger" : "2.0",
-  "info" : {
-    "description" : "API Gateway for Draft Metadata validation",
-    "version" : "0.0.1",
-    "title" : "${title}"
+  "swagger": "2.0",
+  "info": {
+    "version": "1",
+    "title": "${title}"
   },
   "basePath" : "/${environment}",
   "schemes" : [ "https" ],
@@ -37,9 +36,9 @@
             "lambda": []
           }
         ],
-        "x-amazon-apigateway-request-validator" : "Validate query string parameters and headers",
         "x-amazon-apigateway-integration": {
-          "uri": "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda_arn}/invocations",
+          "credentials": "${execution_role_arn}",
+          "uri": "arn:aws:apigateway:${region}:states:action/StartExecution",
           "responses": {
             "default": {
               "statusCode": "200"
@@ -50,11 +49,11 @@
             "integration.request.header.Content-Type": "'application/x-amz-json-1.1'"
           },
           "requestTemplates": {
-            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\"}\"}"
+            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\"}\",\"stateMachineArn\": \"${state_machine_arn}\"}"
           },
-          "passthroughBehavior": "when_no_match",
+          "passthroughBehavior": "when_no_templates",
           "httpMethod": "POST",
-          "type": "aws_proxy"
+          "type": "aws"
         }
       }
     }

--- a/templates/api_gateway/draft_metadata.json.tpl
+++ b/templates/api_gateway/draft_metadata.json.tpl
@@ -8,7 +8,7 @@
   "basePath" : "/${environment}",
   "schemes" : [ "https" ],
   "paths" : {
-    "/draft-metadata/validate/{consignmentId+}" : {
+    "/draft-metadata/validate/{consignmentId}/{fileName}" : {
       "post" : {
         "consumes": [
           "application/json"
@@ -19,6 +19,12 @@
         "parameters": [
           {
             "name": "consignmentId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fileName",
             "in": "path",
             "required": true,
             "type": "string"
@@ -47,10 +53,12 @@
           },
           "requestParameters": {
             "integration.request.header.Accept-Encoding": "'identity'",
-            "integration.request.header.Content-Type": "'application/x-amz-json-1.1'"
+            "integration.request.header.Content-Type": "'application/x-amz-json-1.1'",
+            "integration.request.path.consignmentId": "method.request.path.consignmentId",
+            "integration.request.path.fileName": "method.request.path.fileName"
           },
           "requestTemplates": {
-            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\"}\",\"stateMachineArn\": \"${state_machine_arn}\"}"
+            "application/json": "{\"input\": \"{\\\"consignmentId\\\": \\\"$input.params('consignmentId')\\\", \\\"fileName\\\": \\\"$input.params('fileName')\\\"}\",\"stateMachineArn\": \"${state_machine_arn}\"}"
           },
           "passthroughBehavior": "when_no_templates",
           "httpMethod": "POST",

--- a/templates/iam_policy/invoke_lambda_policy.json.tpl
+++ b/templates/iam_policy/invoke_lambda_policy.json.tpl
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": ${resources}
+    }
+  ]
+}

--- a/templates/iam_policy/lambda_av_policy.json.tpl
+++ b/templates/iam_policy/lambda_av_policy.json.tpl
@@ -43,7 +43,9 @@
         "arn:aws:s3:::${clean_bucket}",
         "arn:aws:s3:::${clean_bucket}/*",
         "arn:aws:s3:::${quarantine_bucket}",
-        "arn:aws:s3:::${quarantine_bucket}/*"
+        "arn:aws:s3:::${quarantine_bucket}/*",
+        "arn:aws:s3:::${metadata_bucket}",
+        "arn:aws:s3:::${metadata_bucket}/*"
       ]
     },
     {

--- a/templates/iam_policy/third_party_api_invocation_template.json.tpl
+++ b/templates/iam_policy/third_party_api_invocation_template.json.tpl
@@ -1,0 +1,31 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "states:InvokeHTTPEndpoint",
+      "Resource": "${step_function_arn}",
+      "Condition": {
+        "StringEquals": {
+          "states:HTTPMethod": "POST"
+        },
+        "StringLike": {
+          "states:HTTPEndpoint": "${api_url}/*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "events:RetrieveConnectionCredentials",
+      "Resource": "${connection_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:${region}:${account_number}:secret:events!connection/*"
+    }
+  ]
+}

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -1,0 +1,74 @@
+{
+  "Comment": "Run antivirus checks on metadata, update database if positive, else trigger metadata validation",
+  "StartAt": "RunAntivirusLambda",
+  "States": {
+    "RunAntivirusLambda": {
+      "Type": "Task",
+      "Resource": "${antivirus_lambda_arn}",
+      "Parameters": {
+        "consignmentId.$": "$.consignmentId",
+        "fileId.$": "$.fileName",
+        "scanType": "metadata"
+      },
+      "ResultPath": "$.output",
+      "Next": "CheckAntivirusResults"
+    },
+    "CheckAntivirusResults": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.output.antivirus.result",
+          "StringEquals": "",
+          "Next": "RunValidateMetadataLambda"
+        },
+        {
+          "Not": {
+            "Variable": "$.output.antivirus.result",
+            "StringEquals": ""
+          },
+          "Next": "PrepareVirusDetectedQueryParams"
+        }
+      ],
+      "Default": "RunValidateMetadataLambda"
+    },
+    "PrepareVirusDetectedQueryParams": {
+      "Type": "Pass",
+      "ResultPath": "$.statusUpdate",
+      "Parameters": {
+        "query": "mutation updateConsignmentStatus($updateConsignmentStatusInput: ConsignmentStatusInput!) { updateConsignmentStatus(updateConsignmentStatusInput: $updateConsignmentStatusInput) }",
+        "variables": {
+          "updateConsignmentStatusInput": {
+            "consignmentId.$": "$.consignmentId",
+            "statusType": "DraftMetadata",
+            "statusValue": "CompletedWithIssues"
+          }
+        }
+      },
+      "Next": "UpdateDraftMetadataStatus"
+    },
+    "UpdateDraftMetadataStatus": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::http:invoke",
+      "Parameters": {
+        "ApiEndpoint": "${consignment_api_url}/graphql",
+        "Method": "POST",
+        "Authentication": {
+          "ConnectionArn": "${consignment_api_connection_arn}"
+        },
+        "Headers": {
+          "Content-Type": "application/json"
+        },
+        "RequestBody.$": "$.statusUpdate"
+      },
+      "End": true
+    },
+    "RunValidateMetadataLambda": {
+      "Type": "Task",
+      "Resource": "${validator_lambda_arn}",
+      "Parameters": {
+        "consignmentId.$": "$.consignmentId"
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
- Give antivirus lambda access to metadata bucket
- Create step function which calls antivirus with `metadata` scanType before calling the draft metadata validator lambda
  - Update api gateway definition to call this step function instead of the lambda directly
  - Create and include a role enabling the execution of the step function from api gateway
- If a virus is found, update the db by calling the consignment API directly from the step function
  - Set up an eventbridge connection to the consignment API, authorised via keycloak, to enable this 
  - Add a policy with the necessary permissions for this invocation and attach it to the step function role

**NB:** For now we set the `DraftMetadata` status to `Failed` if a virus is detected as it is one of the currently allowed values for a consignment status. We may want to consider adding a new `VirusDetected` status in the consignment api (looks like a pretty straightforward PR), although this would mean adding a status value that may only be applicable for one of the consignment stages. Happy to hear thoughts.