### PR TITLE
TDRD-147 and TDRD-148: to accommodate 10,000 files increase timeouts on lambdas in backend checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ HCL Language Support: https://plugins.jetbrains.com/plugin/7808-hashicorp-terraf
 
 3. Clone TDR Configurations repository
    ```
-   [location of project] $ git clone git@github.com/nationalarchives/tdr-configurations.git
+   [location of project] $ git clone git@github.com:nationalarchives/tdr-configurations.git
    ```
 
 4. Clone Terraform modules repository.

--- a/root_backend_checks.tf
+++ b/root_backend_checks.tf
@@ -65,6 +65,7 @@ module "file_upload_data" {
   function_name        = local.file_upload_data_function_name
   handler              = "lambda_handler.handler"
   reserved_concurrency = -1
+  timeout_seconds      = 60
   policies = {
     "TDRFileUploadDataLambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/lambda_s3_policy.json.tpl", {
       function_name              = local.file_upload_data_function_name,
@@ -100,7 +101,7 @@ module "api_update_v2" {
   function_name        = local.api_update_v2_function_name
   handler              = "uk.gov.nationalarchives.api.update.Lambda::update"
   reserved_concurrency = -1
-  timeout_seconds      = 90
+  timeout_seconds      = 600
   policies = {
     "TDRAPIUpdateV2LambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/lambda_policy.json.tpl", {
       function_name  = local.api_update_v2_function_name,


### PR DESCRIPTION
Notes (wip) in confluence https://national-archives.atlassian.net/wiki/spaces/DA/pages/edit-v2/497090679?draftShareId=fe0d2c15-13f0-4264-aac0-12cb3e0325ff on range of timeouts in backend checks

These two are for the overall lambda timeouts - tested these changes on staging with 10,000 files a few times.

(also a small fix in the readme)