### PR TITLE
Allow lambda to use ecr

### DIFF
--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -32,7 +32,7 @@ module "draft_metadata_validator_lambda_2" {
   handler         = "uk.gov.nationalarchives.draftmetadatavalidator.Lambda::handleRequest"
   tags            = local.common_tags
   use_image       = true
-  image_url       = "arn:aws:ecr:eu-west-2:${management_account_number}:repository/draft-metadata-validator"
+  image_url       = "arn:aws:ecr:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:repository/draft-metadata-validator"
   timeout_seconds = 120
   memory_size     = 1024
   policies = {

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -26,6 +26,35 @@ module "draft_metadata_validator_lambda" {
   }
 }
 
+module "draft_metadata_validator_lambda_2" {
+  source          = "./da-terraform-modules/lambda"
+  function_name   = "tdr-draft-metadata-validator-2-${local.environment}"
+  handler         = "uk.gov.nationalarchives.draftmetadatavalidator.Lambda::handleRequest"
+  tags            = local.common_tags
+  use_image       = true
+  image_url       = "arn:aws:ecr:eu-west-2:${management_account_number}:repository/draft-metadata-validator"
+  timeout_seconds = 120
+  memory_size     = 1024
+  policies = {
+    "TDRDraftMetadataValidatorLambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/draft_metadata_validator_lambda.json.tpl", {
+      account_id     = var.tdr_account_number
+      environment    = local.environment
+      parameter_name = local.keycloak_backend_checks_secret_name
+      bucket_name    = local.draft_metadata_s3_bucket_name
+      kms_key_arn    = module.s3_internal_kms_key.kms_key_arn
+    })
+  }
+  plaintext_env_vars = {
+    API_URL            = "${module.consignment_api.api_url}/graphql"
+    AUTH_URL           = local.keycloak_auth_url
+    CLIENT_SECRET_PATH = local.keycloak_backend_checks_secret_name
+    BUCKET_NAME        = local.draft_metadata_s3_bucket_name
+  }
+  lambda_invoke_permissions = {
+    "apigateway.amazonaws.com" = "${module.draft_metadata_api_gateway.api_execution_arn}/*/POST/draft-metadata/validate/{consignmentId+}"
+  }
+}
+
 module "draft_metadata_api_gateway" {
   source = "./da-terraform-modules/apigateway"
   api_definition = templatefile("./templates/api_gateway/draft_metadata.json.tpl", {

--- a/root_draft_metadata_ecr.tf
+++ b/root_draft_metadata_ecr.tf
@@ -1,0 +1,31 @@
+
+#
+module "draft_metadata_validator_lambda_ecr" {
+  source          = "./da-terraform-modules/lambda"
+  function_name   = "tdr-draft-metadata-validator-2-${local.environment}"
+  handler         = "uk.gov.nationalarchives.draftmetadatavalidator.Lambda::handleRequest"
+  tags            = local.common_tags
+  use_image       = true
+  image_url       = "arn:aws:ecr:eu-west-2:${data.aws_ssm_parameter.mgmt_account_number.value}:repository/draft-metadata-validator"
+  timeout_seconds = 120
+  memory_size     = 1024
+  policies = {
+    "TDRDraftMetadataValidatorLambdaPolicyECR${title(local.environment)}" = templatefile("./templates/iam_policy/draft_metadata_validator_lambda.json.tpl", {
+      account_id     = var.tdr_account_number
+      environment    = local.environment
+      parameter_name = local.keycloak_backend_checks_secret_name
+      bucket_name    = local.draft_metadata_s3_bucket_name
+      kms_key_arn    = module.s3_internal_kms_key.kms_key_arn
+    })
+  }
+  plaintext_env_vars = {
+    API_URL            = "graphql"
+    AUTH_URL           = local.keycloak_auth_url
+    CLIENT_SECRET_PATH = local.keycloak_backend_checks_secret_name
+    BUCKET_NAME        = local.draft_metadata_s3_bucket_name
+  }
+}
+
+
+
+

--- a/root_draft_metadata_ecr.tf
+++ b/root_draft_metadata_ecr.tf
@@ -1,5 +1,3 @@
-
-#
 module "draft_metadata_validator_lambda_ecr" {
   source          = "./da-terraform-modules/lambda"
   function_name   = "tdr-draft-metadata-validator-2-${local.environment}"
@@ -25,7 +23,3 @@ module "draft_metadata_validator_lambda_ecr" {
     BUCKET_NAME        = local.draft_metadata_s3_bucket_name
   }
 }
-
-
-
-

--- a/root_draft_metadata_ecr.tf
+++ b/root_draft_metadata_ecr.tf
@@ -1,6 +1,6 @@
 module "draft_metadata_validator_lambda_ecr" {
   source          = "./da-terraform-modules/lambda"
-  function_name   = "tdr-draft-metadata-validator-2-${local.environment}"
+  function_name   = "tdr-draft-metadata-validator-v2-${local.environment}"
   handler         = "uk.gov.nationalarchives.draftmetadatavalidator.Lambda::handleRequest"
   tags            = local.common_tags
   use_image       = true
@@ -17,7 +17,7 @@ module "draft_metadata_validator_lambda_ecr" {
     })
   }
   plaintext_env_vars = {
-    API_URL            = "graphql"
+    API_URL            = "${module.consignment_api.api_url}/graphql"
     AUTH_URL           = local.keycloak_auth_url
     CLIENT_SECRET_PATH = local.keycloak_backend_checks_secret_name
     BUCKET_NAME        = local.draft_metadata_s3_bucket_name


### PR DESCRIPTION
This is just to see if the lambda using the ecr can be created
If it works will delete the old draft-metadata validator and replace with this