### PR TITLE
Add `tdr-user-read` secret env variable to Frontend

### DIFF
--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -26,6 +26,7 @@ data "template_file" "app" {
     app_environment                      = var.environment
     aws_region                           = var.region
     client_secret_path                   = var.client_secret_path
+    read_client_secret_path              = var.read_client_secret_path
     export_api_url                       = var.export_api_url
     backend_checks_api_url               = var.backend_checks_api_url
     alb_ip_a                             = var.public_subnet_ranges[0]

--- a/modules/transfer-frontend/templates/frontend.json.tpl
+++ b/modules/transfer-frontend/templates/frontend.json.tpl
@@ -37,6 +37,10 @@
       {
         "valueFrom": "${client_secret_path}",
         "name": "AUTH_SECRET"
+      },
+      {
+        "valueFrom": "${read_client_secret_path}",
+        "name": "READ_AUTH_SECRET"
       }
     ],
     "environment": [

--- a/modules/transfer-frontend/variables.tf
+++ b/modules/transfer-frontend/variables.tf
@@ -28,6 +28,8 @@ variable "auth_url" {}
 
 variable "client_secret_path" {}
 
+variable "read_client_secret_path" {}
+
 variable "ip_allowlist" {
   description = "IP addresses allowed to access"
   default     = ["0.0.0.0/0"]

--- a/root.tf
+++ b/root.tf
@@ -85,6 +85,7 @@ module "frontend" {
   dns_zone_name_trimmed            = local.dns_zone_name_trimmed
   auth_url                         = local.keycloak_auth_url
   client_secret_path               = module.keycloak_ssm_parameters.params[local.keycloak_tdr_client_secret_name].name
+  read_client_secret_path          = module.keycloak_ssm_parameters.params[local.keycloak_tdr_read_client_secret_name].name
   export_api_url                   = module.export_api.api_url
   backend_checks_api_url           = module.backend_checks_api.api_url
   alb_id                           = module.frontend_alb.alb_id

--- a/root_github.tf
+++ b/root_github.tf
@@ -81,6 +81,7 @@ module "run_keycloak_update_ecs" {
     app_environment            = local.environment
     management_account         = data.aws_ssm_parameter.mgmt_account_number.value
     client_secret_path         = local.keycloak_tdr_client_secret_name
+    read_client_secret_path    = local.keycloak_tdr_read_client_secret_name
     backend_checks_secret_path = local.keycloak_backend_checks_secret_name
     realm_admin_secret_path    = local.keycloak_realm_admin_client_secret_name
     keycloak_properties_path   = local.keycloak_configuration_properties_name

--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -41,6 +41,7 @@ module "keycloak_ssm_parameters" {
   random_parameters = [
     { name = local.keycloak_backend_checks_secret_name, description = "The Keycloak backend checks secret", value = random_uuid.backend_checks_client_secret.result, type = "SecureString" },
     { name = local.keycloak_tdr_client_secret_name, description = "The Keycloak tdr client secret", value = random_uuid.client_secret.result, type = "SecureString" },
+    { name = local.keycloak_tdr_read_client_secret_name, description = "The Keycloak tdr-user-read client secret", value = random_uuid.client_secret.result, type = "SecureString" },
     { name = local.keycloak_user_password_name, description = "The Keycloak user password", value = random_password.keycloak_password.result, type = "SecureString" },
     { name = local.keycloak_admin_password_name, description = "The Keycloak admin password", value = random_password.password.result, type = "SecureString" },
     { name = local.keycloak_govuk_notify_api_key_name, description = "The GovUK Notify API key", value = "to_be_manually_added", type = "SecureString", tier = "Advanced" },
@@ -105,6 +106,7 @@ module "tdr_keycloak_ecs" {
     admin_user_path                   = local.keycloak_admin_user_name
     admin_password_path               = local.keycloak_admin_password_name
     client_secret_path                = local.keycloak_tdr_client_secret_name
+    read_client_secret_path           = local.keycloak_tdr_read_client_secret_name
     backend_checks_client_secret_path = local.keycloak_backend_checks_secret_name
     realm_admin_client_secret_path    = local.keycloak_realm_admin_client_secret_name
     frontend_url                      = module.frontend.frontend_url

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -66,6 +66,7 @@ locals {
 
   keycloak_backend_checks_secret_name        = "/${local.environment}/keycloak/backend_checks_client/secret"
   keycloak_tdr_client_secret_name            = "/${local.environment}/keycloak/client/secret"
+  keycloak_tdr_read_client_secret_name       = "/${local.environment}/keycloak/user_read/secret"
   keycloak_user_password_name                = "/${local.environment}/keycloak/password"
   keycloak_admin_password_name               = "/${local.environment}/keycloak/admin/password"
   keycloak_admin_user_name                   = "/${local.environment}/keycloak/admin/user"


### PR DESCRIPTION
I've created a new `tdr-user-read` client on intg that has `view-users` permissions. This adds the secret for that client so we can fetch user details from keycloak in the frontend.