### PR TITLE
Update `update_waf_and_security_groups_policy`

### DIFF
--- a/root_github.tf
+++ b/root_github.tf
@@ -2,9 +2,11 @@ module "github_update_waf_and_security_groups_policy" {
   source = "./tdr-terraform-modules/iam_policy"
   name   = "TDRUpdateWAFAndSecurityGroupsPolicy${title(local.environment)}"
   policy_string = templatefile("${path.module}/templates/iam_policy/update_waf_and_security_groups_policy.json.tpl", {
-    rule_group_arn    = module.waf.rule_group_arn, ip_set_arn = module.waf.ip_set_arn,
+    rule_group_arn    = module.waf.rule_group_arn,
+    ip_set_arn        = module.waf.ip_set_arn,
     account_id        = data.aws_caller_identity.current.account_id,
     security_group_id = module.frontend.alb_security_group_id
+    environment       = local.environment
   })
 }
 

--- a/templates/iam_policy/update_waf_and_security_groups_policy.json.tpl
+++ b/templates/iam_policy/update_waf_and_security_groups_policy.json.tpl
@@ -8,13 +8,17 @@
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CreateTags",
         "ec2:RevokeSecurityGroupIngress",
-        "wafv2:UpdateRuleGroup"
+        "wafv2:UpdateRuleGroup",
+        "wafv2:Get*",
+        "wafv2:List*",
+        "wafv2:UpdateIPSet"
       ],
       "Resource": [
         "${ip_set_arn}",
         "${rule_group_arn}",
         "arn:aws:ec2:eu-west-2:${account_id}:security-group/${security_group_id}",
-        "arn:aws:wafv2:eu-west-2:${account_id}:REGIONAL/regexpatternset/*/*"
+        "arn:aws:wafv2:eu-west-2:${account_id}:REGIONAL/regexpatternset/*/*",
+        "arn:aws:wafv2:eu-west-2:229554778675:regional/ipset/tdr-apps-${environment}-whitelist/*"
       ]
     },
     {

--- a/templates/iam_policy/update_waf_and_security_groups_policy.json.tpl
+++ b/templates/iam_policy/update_waf_and_security_groups_policy.json.tpl
@@ -18,7 +18,7 @@
         "${rule_group_arn}",
         "arn:aws:ec2:eu-west-2:${account_id}:security-group/${security_group_id}",
         "arn:aws:wafv2:eu-west-2:${account_id}:REGIONAL/regexpatternset/*/*",
-        "arn:aws:wafv2:eu-west-2:229554778675:regional/ipset/tdr-apps-${environment}-whitelist/*"
+        "arn:aws:wafv2:eu-west-2:${account_id}:regional/ipset/tdr-apps-${environment}-whitelist/*"
       ]
     },
     {


### PR DESCRIPTION
The E2E tests use this policy and will require new permissions to update the WAF IPs