### PR TITLE
give draft_metadata front end policy permission to getObject 

### DIFF
--- a/modules/transfer-frontend/templates/draft_metadata_policy.json.tpl
+++ b/modules/transfer-frontend/templates/draft_metadata_policy.json.tpl
@@ -11,7 +11,8 @@
     },
     {
       "Action": [
-        "s3:PutObject"
+        "s3:PutObject",
+        "S3:GetObject"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
The front end needs to download the draft-metadata-errors.json file