### PR TITLE
Allow for SharePoint urls in origin

### DIFF
--- a/templates/api_gateway/sign_cookies_api.json.tpl
+++ b/templates/api_gateway/sign_cookies_api.json.tpl
@@ -79,7 +79,7 @@
                 "method.response.header.Access-Control-Allow-Origin" : "'${upload_cors_urls}'"
               },
               "responseTemplates" : {
-                "application/json" : "#if( $input.params('origin') == 'http://localhost:9000' && $context.stage == 'intg')   #set($context.responseOverride.header.Access-Control-Allow-Origin = 'http://localhost:9000') #end"
+                "application/json" : "#if( $input.params('origin') == 'http://localhost:9000' && $context.stage == 'intg') #set($context.responseOverride.header.Access-Control-Allow-Origin = 'http://localhost:9000') #elseif( $input.params('origin').contains('sharepoint.com')) #set($context.responseOverride.header.Access-Control-Allow-Origin = $input.params('origin'))#end"
               }
             }
           },


### PR DESCRIPTION
SharePoint makes requests for signed cookies via the '/cookies' endpoint.

Ensure that the correct origin, ie the SharePoint site is return in the pre-flight request for the cookie to prevent CORS error on the client side

Ovveride the default origin if the origin in the pre-flight request belongs to the SharePoint domain, ie 'sharepoint.com'.

See details here regarding CORS and pre-flight requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests