### PR TITLE
TDRD-588: increase resources for file format lambda so works with 2GB file

### DIFF
--- a/root_backend_checks.tf
+++ b/root_backend_checks.tf
@@ -133,8 +133,9 @@ module "file_format_v2" {
   function_name        = local.file_format_v2_function_name
   handler              = "uk.gov.nationalarchives.fileformat.Lambda::process"
   reserved_concurrency = -1
-  timeout_seconds      = 60
-  policies = {
+  timeout_seconds      = 300
+  storage_size         = 2560
+  memory_size          = 2560
     "TDRFileFormatV2LambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/lambda_s3_only_policy.json.tpl", {
       function_name   = local.file_format_v2_function_name,
       account_id      = data.aws_caller_identity.current.account_id,

--- a/root_backend_checks.tf
+++ b/root_backend_checks.tf
@@ -136,6 +136,7 @@ module "file_format_v2" {
   timeout_seconds      = 300
   storage_size         = 2560
   memory_size          = 2560
+  policies = {
     "TDRFileFormatV2LambdaPolicy${title(local.environment)}" = templatefile("./templates/iam_policy/lambda_s3_only_policy.json.tpl", {
       function_name   = local.file_format_v2_function_name,
       account_id      = data.aws_caller_identity.current.account_id,


### PR DESCRIPTION
2GB files failing again today.  Suspect that miss-reading logs with AV warnings as actual failures and root cause if that timeouts in this third “file format” lamda in the map.

Seems like partial download happens in each of 5 x 1 min timeout and that therefore it sometimes works on the sixth try.  or do the three lambda share a tmp directory and it has arrived from one of the other lambda in the map that have 5 min timouts? 

Tested with these extra resources and works.  Probably need to revisit how download works and storage, will discuss next week and maybe make card. And more testing.