### PR TITLE
Tdrd 439 handle unexpected errors in tdr draft metadata validator lambda

### DIFF
--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -103,6 +103,8 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
     ]),
     draft_metadata_bucket = local.draft_metadata_s3_bucket_name
     kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
+    account_id            = data.aws_caller_identity.current.account_id,
+    environment           = local.environment
   })
 }
 
@@ -127,6 +129,8 @@ module "draft_metadata_checks" {
     consignment_api_connection_arn = aws_cloudwatch_event_connection.consignment_api_connection.arn,
     validator_lambda_arn           = module.draft_metadata_validator_lambda.lambda_arn,
     draft_metadata_bucket          = local.draft_metadata_s3_bucket_name
+    environment                    = local.environment
+    account_id                     = data.aws_caller_identity.current.account_id
   })
   step_function_role_policy_attachments = {
     "lambda-policy" : aws_iam_policy.draft_metadata_checks_policy.arn,

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -102,8 +102,8 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
       module.draft_metadata_validator_lambda.lambda_arn
     ]),
     draft_metadata_bucket = local.draft_metadata_s3_bucket_name
-    s3_kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
-    sns_kms_key_arn           = module.encryption_key.kms_key_arn
+    s3_kms_key_arn        = module.s3_internal_kms_key.kms_key_arn
+    sns_kms_key_arn       = module.encryption_key.kms_key_arn
     account_id            = data.aws_caller_identity.current.account_id
     environment           = local.environment
   })

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -104,7 +104,7 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
     draft_metadata_bucket = local.draft_metadata_s3_bucket_name
     kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
     sns_key_arn           = module.encryption_key.kms_key_arn
-    account_id            = data.aws_caller_identity.current.account_id,
+    account_id            = data.aws_caller_identity.current.account_id
     environment           = local.environment
   })
 }

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -103,6 +103,7 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
     ]),
     draft_metadata_bucket = local.draft_metadata_s3_bucket_name
     kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
+    sns_key_arn           = module.encryption_key.kms_key_arn
     account_id            = data.aws_caller_identity.current.account_id,
     environment           = local.environment
   })

--- a/root_draft_metadata.tf
+++ b/root_draft_metadata.tf
@@ -102,8 +102,8 @@ resource "aws_iam_policy" "draft_metadata_checks_policy" {
       module.draft_metadata_validator_lambda.lambda_arn
     ]),
     draft_metadata_bucket = local.draft_metadata_s3_bucket_name
-    kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
-    sns_key_arn           = module.encryption_key.kms_key_arn
+    s3_kms_key_arn           = module.s3_internal_kms_key.kms_key_arn
+    sns_kms_key_arn           = module.encryption_key.kms_key_arn
     account_id            = data.aws_caller_identity.current.account_id
     environment           = local.environment
   })

--- a/templates/iam_policy/metadata_checks_policy.json.tpl
+++ b/templates/iam_policy/metadata_checks_policy.json.tpl
@@ -27,6 +27,15 @@
         "kms:Decrypt"
       ],
       "Resource": "${kms_key_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish"
+      ],
+      "Resource": [
+        "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}"
+      ]
     }
   ]
 }

--- a/templates/iam_policy/metadata_checks_policy.json.tpl
+++ b/templates/iam_policy/metadata_checks_policy.json.tpl
@@ -29,8 +29,8 @@
         "kms:Decrypt"
       ],
       "Resource": [
-        "${kms_key_arn}",
-        "${sns_key_arn}"
+        "${s3_kms_key_arn}",
+        "${sns_kms_key_arn}"
       ]
     },
     {

--- a/templates/iam_policy/metadata_checks_policy.json.tpl
+++ b/templates/iam_policy/metadata_checks_policy.json.tpl
@@ -28,7 +28,10 @@
         "kms:GenerateDataKey",
         "kms:Decrypt"
       ],
-      "Resource": "${kms_key_arn}"
+      "Resource": [
+        "${kms_key_arn}",
+        "${sns_key_arn}
+      ]
     },
     {
       "Effect": "Allow",

--- a/templates/iam_policy/metadata_checks_policy.json.tpl
+++ b/templates/iam_policy/metadata_checks_policy.json.tpl
@@ -30,7 +30,7 @@
       ],
       "Resource": [
         "${kms_key_arn}",
-        "${sns_key_arn}
+        "${sns_key_arn}"
       ]
     },
     {

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -32,7 +32,22 @@
           "Next": "RunValidateMetadataLambda"
         }
       ],
-      "Default": "WriteVirusDetectedJsonToS3"
+      "Default": "SendSNSVirusMessage"
+    },
+    "SendSNSVirusMessage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
+        "Message": {
+          "consignmentId.$": "$.consignmentId",
+          "environment": "${environment}",
+          "metaDataError": "Virus found in metadata file",
+          "cause.$": "$.output.antivirus.result"
+        }
+      },
+      "Next": "WriteVirusDetectedJsonToS3",
+      "ResultPath": null
     },
     "WriteVirusDetectedJsonToS3": {
       "Type": "Task",
@@ -117,16 +132,16 @@
     },
     "SendSNSErrorMessage": {
       "Type": "Task",
-        "Resource": "arn:aws:states:::sns:publish",
-         "Parameters": {
-         "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
-         "Message": {
-           "consignmentId.$" : "$.consignmentId",
-           "environment"   : "${environment}",
-           "metaDataError" : "An unknown error has been triggered",
-           "cause.$"         : "States.Format('Metadata validation lambda: {}',$.validatorLambdaResult.body)"
-         }
-       },
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
+        "Message": {
+          "consignmentId.$": "$.consignmentId",
+          "environment": "${environment}",
+          "metaDataError": "An unknown error has been triggered",
+          "cause.$": "States.Format('Metadata validation lambda: {}',$.validatorLambdaResult.body)"
+        }
+      },
       "Next": "WriteUnknownErrorJsonToS3",
       "ResultPath": null
     },

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -106,16 +106,14 @@
     },
     "CheckValidatorLambdaResult": {
       "Type": "Choice",
-     "Choices": [
-       {
-          {
-             "Variable": "$.validatorLambdaResult.statusCode",
-             "NumericEquals": 500
-           }
-         "Next": "SendSNSErrorMessage"
-       }
-     ],
-     "Default": "EndState"
+      "Choices": [
+        {
+          "Variable": "$.validatorLambdaResult.statusCode",
+          "NumericEquals": 500,
+          "Next": "SendSNSErrorMessage"
+        }
+      ],
+      "Default": "EndState"
     },
     "SendSNSErrorMessage": {
       "Type": "Task",

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -125,7 +125,7 @@
          "Message": "{
            \"consignmentId\" : \"$.consignmentId\",
            \"environment\"   : \"${environment}\",
-           \"error\"         : \"Unexpected error in draft metadata validation\",
+           \"metaDataError\" : \"Unexpected error in draft metadata validation\",
            \"cause\"         : \"$.validatorLambdaResult.body\"
          }"
        },

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -149,6 +149,15 @@
     },
     "EndState": {
       "Type": "Succeed"
+    },
+    "SendSNSMessage": {
+      "Type": "Task",
+       "Resource": "arn:aws:states:::sns:publish",
+       "Parameters": {
+          "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
+          "Message": "Your custom message for Slack"
+       },
+       "End": true
     }
   }
 }

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -125,8 +125,8 @@
          "Message": "{
            \"consignmentId\" : \"$.consignmentId\",
            \"environment\"   : \"${environment}\",
-           \"metaDataError\" : \"Unexpected error in draft metadata validation\",
-           \"cause\"         : \"$.validatorLambdaResult.body\"
+           \"metaDataError\" : \"An unknown error has been triggered\",
+           \"cause\"         : \"Metadata validation lambda: $.validatorLambdaResult.body\"
          }"
        },
       "Next": "WriteUnknownErrorJsonToS3"

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -113,14 +113,27 @@
     },
     "CheckValidatorLambdaResult": {
       "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.validatorLambdaResult.statusCode",
-          "NumericEquals": 500,
-          "Next": "SendSNSErrorMessage"
-        }
-      ],
-      "Default": "EndState"
+     "Choices": [
+       {
+         "And": [
+           {
+             "Variable": "$.validatorLambdaResult.statusCode",
+             "NumericEquals": 500
+           },
+           {
+             "Variable": "$.environment",
+             "StringEquals": "prod"
+           }
+         ],
+         "Next": "SendSNSErrorMessage"
+       },
+       {
+         "Variable": "$.validatorLambdaResult.statusCode",
+         "NumericEquals": 500,
+         "Next": "WriteUnknownErrorJsonToS3"
+       }
+     ],
+     "Default": "EndState"
     },
     "SendSNSErrorMessage": {
       "Type": "Task",

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -112,10 +112,24 @@
         {
           "Variable": "$.validatorLambdaResult.statusCode",
           "NumericEquals": 500,
-          "Next": "WriteUnknownErrorJsonToS3"
+          "Next": "SendSNSErrorMessage"
         }
       ],
       "Default": "EndState"
+    },
+    "SendSNSErrorMessage": {
+      "Type": "Task",
+        "Resource": "arn:aws:states:::sns:publish",
+         "Parameters": {
+         "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
+         "Message": "{
+           \"consignmentId\" : \"$.consignmentId\",
+           \"environment\"   : \"${environment}\",
+           \"error\"         : \"Unexpected error in draft metadata validation\",
+           \"cause\"         : \"$.validatorLambdaResult.body\"
+         }"
+       },
+      "Next": "WriteUnknownErrorJsonToS3"
     },
     "WriteUnknownErrorJsonToS3": {
       "Type": "Task",
@@ -149,15 +163,6 @@
     },
     "EndState": {
       "Type": "Succeed"
-    },
-    "SendSNSMessage": {
-      "Type": "Task",
-       "Resource": "arn:aws:states:::sns:publish",
-       "Parameters": {
-          "TopicArn": "arn:aws:sns:eu-west-2:${account_id}:tdr-notifications-${environment}",
-          "Message": "Your custom message for Slack"
-       },
-       "End": true
     }
   }
 }


### PR DESCRIPTION
The step function will send a message to the notification topic if there is an unexpected error that has been handled in the draft-metadata-validator lambda returning statusCode 500. Although this should never happen, when the saving metadata changes have been made, it will enable the tdr team to be proactive if there are unexpected errors in prod that affect the users.

Also added slack for virus detected as we are getting false positives
