### PR TITLE
TDRD-613: increase keycloak memory on intg so compatible with CPU

### DIFF
--- a/root_keycloak.tf
+++ b/root_keycloak.tf
@@ -131,7 +131,7 @@ module "tdr_keycloak_ecs" {
   environment                  = local.environment
   execution_role               = module.keycloak_execution_role.role.arn
   load_balancer_container_port = 8080
-  memory                       = 3072
+  memory                       = local.environment == "intg" ? 4096 : 3072
   private_subnets              = module.shared_vpc.private_backend_checks_subnets
   security_groups              = [module.keycloak_ecs_security_group.security_group_id]
   service_name                 = "keycloak_service_${local.environment}"


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html