### PR TITLE
Fix terrform warnings plan fix

### DIFF
--- a/modules/shared-vpc/root.tf
+++ b/modules/shared-vpc/root.tf
@@ -69,7 +69,7 @@ resource "aws_route" "internet_access" {
 # Create a NAT gateway with an Elastic IP for each private subnet to get internet connectivity
 resource "aws_eip" "gw" {
   count      = var.az_count
-  vpc        = true
+  domain     = "vpc"
   depends_on = [aws_internet_gateway.gw]
 
   tags = merge(

--- a/root.tf
+++ b/root.tf
@@ -144,20 +144,15 @@ module "upload_file_cloudfront_dirty_s3" {
   cloudfront_oai               = module.cloudfront_upload.cloudfront_oai_iam_arn
   cloudfront_distribution_arns = [module.cloudfront_upload.cloudfront_arn]
 }
-# This is the only module that uses the canonical user grants in the tdr-terraform-modules/s3 module
-# Grants are no longer the recommended way to grant access to a bucket. The s3 module will use the
-# canonical user grants id in the bucket policy with permissions equivalent to 'FULL_CONTROL'
-# tdr-terraform-modules/s3 module will be deprecated.
+
 module "upload_file_cloudfront_logs" {
-  source      = "./tdr-terraform-modules/s3"
-  project     = var.project
-  function    = "upload-cloudfront-logs"
-  common_tags = local.common_tags
-  access_logs = false
-  canonical_user_grants = [
-    { id = local.logs_delivery_canonical_user_id, permissions = ["FULL_CONTROL"] },
-    { id = data.aws_canonical_user_id.canonical_user.id, permissions = ["FULL_CONTROL"] }
-  ]
+  source                       = "./tdr-terraform-modules/s3"
+  project                      = var.project
+  function                     = "upload-cloudfront-logs"
+  common_tags                  = local.common_tags
+  bucket_policy                = "upload_cloudfront_logs"
+  aws_logs_delivery_account_id = local.aws_logs_delivery_account_id
+  access_logs                  = false
 }
 
 module "cloudfront_upload" {

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -151,4 +151,6 @@ locals {
   aws_guardduty_ecr_arn = module.tdr_configuration.terraform_config["aws_guardduty_ecr_arn"]
 
   rds_retention_period_days = local.environment == "prod" ? 30 : 7
+
+  aws_logs_delivery_account_id = module.tdr_configuration.terraform_config["aws_logs_delivery_account_id"]
 }


### PR DESCRIPTION
Terraform allowed the use of a canonical user id for the principal in an s3 bucket policy. AWS would change this to an AWS principal with corresponding account id. The terraform and resources would never look in sync. Use account id in terraform. Remove all refs to canonical users