### PR TITLE
Initial lifecyle rule for s3 dirty bucket

### DIFF
--- a/root_s3_object_lifecycle.tf
+++ b/root_s3_object_lifecycle.tf
@@ -2,6 +2,8 @@ locals {
   default_expiration_days = local.environment == "prod" ? 30 : 7
 
   backend_checks_bucket_policy_status = "Enabled"
+
+  dirty_bucket_policy_status = local.environment == "intg" ? "Enabled" : "Disabled"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "backend_checks_results_s3_bucket" {
@@ -9,6 +11,20 @@ resource "aws_s3_bucket_lifecycle_configuration" "backend_checks_results_s3_buck
   rule {
     id     = "delete-backend-checks-results-bucket-objects"
     status = local.backend_checks_bucket_policy_status
+    expiration {
+      days = local.default_expiration_days
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = local.default_expiration_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "dirty_s3_buckets" {
+  bucket = module.upload_file_cloudfront_dirty_s3.s3_bucket_id
+  rule {
+    id     = "delete-dirty-buckets-objects"
+    status = local.dirty_bucket_policy_status
     expiration {
       days = local.default_expiration_days
     }


### PR DESCRIPTION
Dirty bucket copies of records are temporary until copied to clean or quarantine buckets during backend checks