### PR TITLE
TDRD-675 - Modify RunValidateMetadataLambda

### DIFF
--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -117,13 +117,16 @@
         "consignmentId.$": "$.consignmentId"
       },
       "ResultPath": "$.validatorLambdaResult",
-      "Next": "EndState",
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": "$.error",
           "Next": "SendSNSErrorMessage"
         }
-      ]
+      ],
+      "Next": "EndState"
     },
     "SendSNSErrorMessage": {
       "Type": "Task",
@@ -134,7 +137,7 @@
           "consignmentId.$": "$.consignmentId",
           "environment": "${environment}",
           "metaDataError": "An unknown error has been triggered",
-          "cause.$": "States.Format('Metadata validation lambda: {}',$.validatorLambdaResult.body)"
+          "cause.$": "States.Format('Metadata validation lambda: {}',$.error.Cause)"
         }
       },
       "Next": "WriteUnknownErrorJsonToS3",
@@ -159,7 +162,7 @@
                   "validationProcess": "LAMBDA",
                   "property": "lambda_validation",
                   "errorKey": "unexpected_error",
-                  "message.$": "$.validatorLambdaResult.body"
+                  "message.$": "$.error.Cause"
                 }
               ],
               "data": []

--- a/templates/step_function/metadata_checks_definition.json.tpl
+++ b/templates/step_function/metadata_checks_definition.json.tpl
@@ -117,18 +117,13 @@
         "consignmentId.$": "$.consignmentId"
       },
       "ResultPath": "$.validatorLambdaResult",
-      "Next": "CheckValidatorLambdaResult"
-    },
-    "CheckValidatorLambdaResult": {
-      "Type": "Choice",
-      "Choices": [
+      "Next": "EndState",
+      "Catch": [
         {
-          "Variable": "$.validatorLambdaResult.statusCode",
-          "NumericEquals": 500,
+          "ErrorEquals": ["States.ALL"],
           "Next": "SendSNSErrorMessage"
         }
-      ],
-      "Default": "EndState"
+      ]
     },
     "SendSNSErrorMessage": {
       "Type": "Task",


### PR DESCRIPTION
Removes the `CheckValidatorLambdaResult` since the The `RunValidateMetadataLambda` now properly fails if errors occur.
Example of successful step function run : https://229554778675-xtzq76ks.eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:229554778675:execution:TDRMetadataChecksIntg:ef615165-28eb-46d8-a0d6-3006df9c415c

an example of fail path:

https://229554778675-xtzq76ks.eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:229554778675:execution:TDRMetadataChecksIntg:2a8ec96f-af70-4bf4-8fa1-7ac28c11701a