### PR TITLE
Remove backup tags on intg

### DIFF
--- a/root_locals.tf
+++ b/root_locals.tf
@@ -12,7 +12,7 @@ locals {
   environment_full_name = local.environment_full_name_map[local.environment]
 
   aws_back_up_role = module.aws_backup_configuration.terraform_config["aws_service_backup_role"]
-  aws_back_up_tags = local.environment == "intg" ? { "BackupPolicy" = "7-day-no-cold" } : null
+  aws_back_up_tags = false ? { "BackupPolicy" = "7-day-no-cold" } : null
 
   common_tags = tomap(
     {


### PR DESCRIPTION
AWS back up was tested on intg on selected resources

Revert the tags so these resources are no longer backed up

Only production resources will be backed up