### PR TITLE
Support for sending user emails

### DIFF
--- a/root_transfer_service.tf
+++ b/root_transfer_service.tf
@@ -158,6 +158,7 @@ module "transfer_service_ecs_task" {
       transfer_service_client_secret_path = local.keycloak_tdr_transfer_service_secret_name
       throttle_amount                     = 50
       throttle_per_ms                     = 10
+      user_email_sns_topic_arn            = module.notifications_topic.sns_arn
   })
   container_name               = "transfer-service"
   cpu                          = 512

--- a/templates/ecs_tasks/transfer_service.json.tpl
+++ b/templates/ecs_tasks/transfer_service.json.tpl
@@ -61,6 +61,10 @@
       {
         "name": "THROTTLE_PER_MS",
         "value": "${throttle_per_ms}"
+      },
+      {
+        "name": "USER_EMAIL_SNS_TOPIC_ARN",
+        "value": "${user_email_sns_topic_arn}"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
Transfer service to send user emails to notify that uploads from SharePoint to TDR have completed or failed