### PR TITLE
Remove references to the Akka licence token

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -30,7 +30,6 @@ data "template_file" "app" {
     frontend_url                 = var.frontend_url
     da_reference_generator_url   = var.da_reference_generator_url
     da_reference_generator_limit = var.da_reference_generator_limit
-    akka_licence_token_name      = var.akka_licence_token_name
     akka_licence_key_name        = var.akka_licence_key_name
   }
 }

--- a/modules/consignment-api/templates/consignment-api.json.tpl
+++ b/modules/consignment-api/templates/consignment-api.json.tpl
@@ -35,10 +35,6 @@
         "name": "DB_ADDR"
       },
       {
-        "valueFrom": "${akka_licence_token_name}",
-        "name": "AKKA_LICENCE_TOKEN"
-      },
-      {
         "valueFrom": "${akka_licence_key_name}",
         "name": "AKKA_LICENCE_KEY"
       }

--- a/modules/consignment-api/variables.tf
+++ b/modules/consignment-api/variables.tf
@@ -53,8 +53,6 @@ variable "db_instance_resource_id" {}
 
 variable "aws_guardduty_ecr_arn" {}
 
-variable "akka_licence_token_name" {}
-
 variable "akka_licence_key_name" {}
 
 variable "aws_backup_tag" {

--- a/root.tf
+++ b/root.tf
@@ -71,7 +71,6 @@ module "consignment_api" {
   da_reference_generator_url     = local.da_reference_generator_url
   da_reference_generator_limit   = local.da_reference_generator_limit
   aws_guardduty_ecr_arn          = local.aws_guardduty_ecr_arn
-  akka_licence_token_name        = local.akka_licence_token_name
   akka_licence_key_name          = local.akka_licence_key_name
 }
 

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -73,8 +73,6 @@ locals {
 
   keycloak_auth_url = "https://auth.${local.dns_zone_name_trimmed}"
 
-  akka_licence_token_name = "/${local.environment}/akka/licence_token"
-
   akka_licence_key_name = "/${local.environment}/akka/licence_key"
 
   keycloak_backend_checks_secret_name            = "/${local.environment}/keycloak/backend_checks_client/secret"

--- a/root_ssm_parameters.tf
+++ b/root_ssm_parameters.tf
@@ -21,19 +21,6 @@ module "reporting_lambda_ssm_parameters" {
   tags = merge(local.common_tags, local.manual_input_tag)
 }
 
-module "akka_licence_token_ssm_parameters" {
-  source = "./da-terraform-modules/ssm_parameter"
-  parameters = [
-    {
-      name        = local.akka_licence_token_name,
-      description = "Licence token for Akka"
-      type        = "SecureString"
-      value       = "To be manually added"
-    }
-  ]
-  tags = merge(local.common_tags, local.manual_input_tag)
-}
-
 module "akka_licence_key_ssm_parameters" {
   source = "./da-terraform-modules/ssm_parameter"
   parameters = [


### PR DESCRIPTION
Akka licence token used at build time, not runtime

Should not be referenced by the ECS task