### PR TITLE
fix syntax for disable_inactive_judgment_users_schedule event

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -772,7 +772,7 @@ module "disable_inactive_judgment_users_scheduled_event" {
   source                  = "./da-terraform-modules/cloudwatch_events"
   count                   = local.environment == "prod" ? 0 : 1
   rule_description        = "Scheduled event to disable inactive judgment Keycloak users"
-  schedule                = "rate(30 day)"
+  schedule                = "rate(30 days)"
   rule_name               = "disable-inactive-judgment-keycloak-users"
   lambda_event_target_arn = module.inactive_keycloak_users_lambda.lambda_arn
   input = jsonencode({


### PR DESCRIPTION
Already applied to intg