### PR TITLE
remove fab dry_run

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -765,6 +765,7 @@ module "inactive_keycloak_users_lambda" {
     REPORTING_CLIENT_SECRET_PATH  = local.keycloak_reporting_client_secret_name
     ENVIRONMENT                   = local.environment
     NOTIFICATIONS_TOPIC_ARN       = module.notifications_topic.sns_arn
+    DISABLE_USERS_DRY_RUN         = local.disable_users_dry_run
   }
 }
 

--- a/root.tf
+++ b/root.tf
@@ -776,7 +776,7 @@ module "disable_inactive_judgment_users_scheduled_event" {
   lambda_event_target_arn = module.inactive_keycloak_users_lambda.lambda_arn
   input = jsonencode({
     userType             = "judgment_user"
-    inactivityPeriodDays = 770
+    inactivityPeriodDays = 730
   })
 }
 

--- a/root.tf
+++ b/root.tf
@@ -771,12 +771,12 @@ module "inactive_keycloak_users_lambda" {
 module "disable_inactive_judgment_users_scheduled_event" {
   source                  = "./da-terraform-modules/cloudwatch_events"
   rule_description        = "Scheduled event to disable inactive judgment Keycloak users"
-  schedule                = "rate(775 days)"
+  schedule                = "rate(30 days)"
   rule_name               = "disable-inactive-judgment-keycloak-users"
   lambda_event_target_arn = module.inactive_keycloak_users_lambda.lambda_arn
   input = jsonencode({
     userType             = "judgment_user"
-    inactivityPeriodDays = 180
+    inactivityPeriodDays = 770
   })
 }
 

--- a/root.tf
+++ b/root.tf
@@ -765,14 +765,13 @@ module "inactive_keycloak_users_lambda" {
     REPORTING_CLIENT_SECRET_PATH  = local.keycloak_reporting_client_secret_name
     ENVIRONMENT                   = local.environment
     NOTIFICATIONS_TOPIC_ARN       = module.notifications_topic.sns_arn
-    DISABLE_USERS_DRY_RUN         = local.disable_users_dry_run
   }
 }
 
 module "disable_inactive_judgment_users_scheduled_event" {
   source                  = "./da-terraform-modules/cloudwatch_events"
   rule_description        = "Scheduled event to disable inactive judgment Keycloak users"
-  schedule                = "rate(30 days)"
+  schedule                = "rate(775 days)"
   rule_name               = "disable-inactive-judgment-keycloak-users"
   lambda_event_target_arn = module.inactive_keycloak_users_lambda.lambda_arn
   input = jsonencode({

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -159,7 +159,6 @@ locals {
   block_skip_metadata_review     = false
   block_judgment_press_summaries = local.environment == "prod" ? true : false
 
-  disable_users_dry_run         = true
   draft_metadata_s3_bucket_name = "${var.project}-draft-metadata-${local.environment}"
 
   flat_format_bucket_name          = "tdr-export-${local.environment}"

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -159,6 +159,7 @@ locals {
   block_skip_metadata_review     = false
   block_judgment_press_summaries = local.environment == "prod" ? true : false
 
+  disable_users_dry_run         = false
   draft_metadata_s3_bucket_name = "${var.project}-draft-metadata-${local.environment}"
 
   flat_format_bucket_name          = "tdr-export-${local.environment}"


### PR DESCRIPTION
leave env variable in so dry run can be easily run if want to see how many users might be disabled. set to false 
Implement to be scheduled to run every 30 days, and disabling users who have not user TDR for 2 years.
Phase 1: 2 years / 730 days