### PR TITLE
Transfer service env variable to support SharePoint functionality

### DIFF
--- a/root_transfer_service.tf
+++ b/root_transfer_service.tf
@@ -15,6 +15,11 @@ locals {
   block_api_documentation = local.is_lower_environment ? false : true
   block_service_endpoints = local.environment == "prod" ? true : false
   block_tdr_custom_tags   = local.is_lower_environment ? false : true
+
+  # Temporary expedient to handle transferring bodies who do not wish the SharePoint site name to appear as part of the arrangement in the public catalogue
+  # Should be removed when proper UI solution implemented
+  # Contain list of transferring body codes as a comma separated string, for example: "TDR-BODY1,TDR-BODY2, ... etc ..."
+  ignore_site_name_bodies = ""
 }
 
 module "transfer_service_execution_role" {
@@ -185,6 +190,7 @@ module "transfer_service_ecs_task" {
       block_tdr_custom_tags               = local.block_tdr_custom_tags
       log_body                            = false
       log_headers                         = false
+      ignore_site_name_bodies             = local.ignore_site_name_bodies
   })
   container_name               = "transfer-service"
   cpu                          = 512

--- a/templates/ecs_tasks/transfer_service.json.tpl
+++ b/templates/ecs_tasks/transfer_service.json.tpl
@@ -109,6 +109,10 @@
       {
         "name": "LOG_BODY",
         "value": "${log_body}"
+      },
+      {
+        "name": "IGNORE_SITE_NAME_BODIES",
+        "value": "${ignore_site_name_bodies}"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
Some transferring bodies when transferring from SharePoint may not want the 'site name' included in the arrangement

As a temporary measure until a UI solution is available provide a list of such bodies, so metadata processing can set the 'file path' property value correctly