### PR TITLE
TDRD-1461: consignmentapi ecs task memory bump

### DIFF
--- a/modules/consignment-api/ecs.tf
+++ b/modules/consignment-api/ecs.tf
@@ -2,7 +2,7 @@ locals {
   app_port           = 8080
   ecr_account_number = var.environment == "sbox" ? data.aws_caller_identity.current.account_id : data.aws_ssm_parameter.mgmt_account_number.value
   cpu                = var.environment == "intg" ? "1024" : "2048"
-  memory             = var.environment == "intg" ? "2048" : "4096"
+  memory             = var.environment == "intg" ? "2048" : "6144"
 }
 
 resource "aws_ecs_cluster" "consignment_api_ecs" {

--- a/root_consignment_export.tf
+++ b/root_consignment_export.tf
@@ -95,7 +95,7 @@ module "consignment_export_ecs_task" {
   cpu              = local.environment == "intg" ? 1024 : 2048
   environment      = local.environment
   execution_role   = module.consignment_export_execution_role.role.arn
-  memory           = local.environment == "intg" ? 2048 : 4096
+  memory           = local.environment == "intg" ? 2048 : 6144
   private_subnets  = []
   security_groups  = [module.consignment_export_ecs_security_group.security_group_id]
   task_family_name = "consignment-export-${local.environment}"

--- a/root_consignment_export.tf
+++ b/root_consignment_export.tf
@@ -95,7 +95,7 @@ module "consignment_export_ecs_task" {
   cpu              = local.environment == "intg" ? 1024 : 2048
   environment      = local.environment
   execution_role   = module.consignment_export_execution_role.role.arn
-  memory           = local.environment == "intg" ? 2048 : 6144
+  memory           = local.environment == "intg" ? 2048 : 4096
   private_subnets  = []
   security_groups  = [module.consignment_export_ecs_security_group.security_group_id]
   task_family_name = "consignment-export-${local.environment}"


### PR DESCRIPTION
The export of 10k records with full metadata runs out of memory in the consignment api at 4GB, so test it at 6GB.
CPU stays as is as once on 2 can increase memory independently.
Integration remains smaller.