### PR TITLE
Use general deletion policy for export bucket

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -595,6 +595,7 @@ module "export_step_function" {
     bagit_export_judgment_bucket   = module.export_bucket_judgment.s3_bucket_name
     consignment_api_url            = module.consignment_api.api_url
     consignment_api_connection_arn = aws_cloudwatch_event_connection.consignment_api_export_connection.arn
+    block_mock_series_ingest       = local.block_mock_series_ingest
   })
   step_function_name = "ConsignmentExport"
   environment        = local.environment
@@ -625,7 +626,7 @@ module "flat_format_export_bucket" {
     read_access_roles     = [local.dr2_copy_files_role]
     aws_backup_local_role = local.aws_back_up_local_role
   })
-  lifecycle_rules                = local.environment == "prod" ? [] : local.export_bucket_lifecycle_rules
+  lifecycle_rules                = local.environment == "prod" ? [] : local.background_clean_up_lifecycle_rules
   s3_data_bucket_additional_tags = local.aws_back_up_tags
   enable_request_metrics_all     = local.environment == "prod"
 }

--- a/root_locals.tf
+++ b/root_locals.tf
@@ -243,4 +243,6 @@ locals {
   athena_metadata_checks_database_name = "athena-tdr-metadata-checks-${local.environment}"
 
   metadata_version_override = ""
+
+  block_mock_series_ingest = local.environment == "intg" ? false : true
 }

--- a/root_s3_object_lifecycle.tf
+++ b/root_s3_object_lifecycle.tf
@@ -61,4 +61,21 @@ locals {
         noncurrent_days = local.default_expiration_days
       }
   }]
+
+  background_clean_up_lifecycle_rules = [
+    {
+      id     = "background-clean-up"
+      status = local.export_bucket_policy_status
+      expiration = {
+        days = local.default_expiration_days
+      }
+      filter = {
+        tag = {
+
+        }
+      }
+      noncurrent_version_expiration = {
+        noncurrent_days = local.default_expiration_days
+      }
+  }]
 }

--- a/templates/step_function/consignment_export_definition.json.tpl
+++ b/templates/step_function/consignment_export_definition.json.tpl
@@ -142,6 +142,10 @@
                         {
                           "Name": "TASK_TOKEN_ENV_VARIABLE",
                           "Value.$": "$$.Task.Token"
+                        },
+                        {
+                          "Name": "BLOCK_MOCK_SERIES_INGEST",
+                          "Value": "${block_mock_series_ingest}"
                         }
                       ]
                     }


### PR DESCRIPTION
'Mock' series have ingest message switched off so object are not getting tagged for deletion in lower environments

To manage bucket size do a general clean up all objects