### PR TITLE
TDRD-1461: increase front end memory 

### DIFF
--- a/modules/transfer-frontend/ecs.tf
+++ b/modules/transfer-frontend/ecs.tf
@@ -1,7 +1,7 @@
 locals {
   app_port = 9000
   cpu      = var.environment == "intg" ? "512" : "1024"
-  memory   = var.environment == "intg" ? "1024" : var.environment == "staging" ? "4096" : "2048"
+  memory   = var.environment == "intg" ? "1024" : "4096"
 }
 
 resource "aws_ecs_cluster" "frontend_ecs" {


### PR DESCRIPTION
- to allow for metadata download of 10k full metadata.
- previously only increased on staging, now do same on prod
- intg remains low, not intended to encounter these capacity levels.