### PR TITLE
Tdrd 1547 review and fix security group descriptions

### DIFF
--- a/modules/consignment-api/security.tf
+++ b/modules/consignment-api/security.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "lb" {
 # Traffic to the ECS cluster should only come from the application load balancer
 resource "aws_security_group" "ecs_tasks" {
   name        = "${var.app_name}-ecs-tasks-security-group-${var.environment}"
-  description = "Allow inbound access to the ECS from the keycloak load balancer only"
+  description = "Allow inbound access to the ECS from the consignment API load balancer only"
   vpc_id      = var.vpc_id
 
   ingress {

--- a/modules/consignment-api/security.tf
+++ b/modules/consignment-api/security.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "lb" {
 # Traffic to the ECS cluster should only come from the application load balancer
 resource "aws_security_group" "ecs_tasks" {
   name        = "${var.app_name}-ecs-tasks-security-group-${var.environment}"
-  description = "Allow inbound access from the keycloak load balancer only"
+  description = "Allow inbound access to the ECS from the keycloak load balancer only"
   vpc_id      = var.vpc_id
 
   ingress {

--- a/modules/database-migrations/lambda.tf
+++ b/modules/database-migrations/lambda.tf
@@ -53,7 +53,7 @@ resource "aws_lambda_function" "database_migration_function" {
 
 resource "aws_security_group" "db_migration" {
   name        = "db-migration-security-group-${var.environment}"
-  description = "Controls access to the keycloak load balancer"
+  description = "Controls access for the database migration Lambda to the database"
   vpc_id      = var.vpc_id
 
   egress {

--- a/modules/transfer-frontend/security.tf
+++ b/modules/transfer-frontend/security.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "lb" {
 # Traffic to the ECS cluster should only come from the application load balancer
 resource "aws_security_group" "ecs_tasks" {
   name        = "${var.app_name}-ecs-tasks-security-group-${var.environment}"
-  description = "Allow inbound access from the frontend load balancer only"
+  description = "Allow inbound access to the ECS from the frontend load balancer only"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -55,7 +55,7 @@ resource "aws_security_group" "ecs_tasks" {
 
 resource "aws_security_group" "redis" {
   name        = "${var.app_name}-redis-sg-${var.environment}"
-  description = "Allow inbound access from the frontend load balancer only"
+  description = "Allow inbound access for the elasticache redis replication group from the frontend load balancer only"
   vpc_id      = var.vpc_id
 
   ingress {

--- a/root.tf
+++ b/root.tf
@@ -71,7 +71,7 @@ module "consignment_api" {
   frontend_url                   = module.frontend.frontend_url
   dns_zone_name_trimmed          = local.dns_zone_name_trimmed
   db_instance_resource_id        = module.consignment_api_database.resource_id
-  create_users_security_group_id = flatten([module.create_db_users_lambda.create_users_lambda_security_group_id, module.create_bastion_user_lambda.create_users_lambda_security_group_id])
+  create_users_security_group_id = flatten([module.create_db_users_lambda.create_users_lambda_security_group_id])
   da_reference_generator_url     = local.da_reference_generator_url
   da_reference_generator_limit   = local.da_reference_generator_limit
   aws_guardduty_ecr_arn          = local.aws_guardduty_ecr_arn
@@ -407,22 +407,6 @@ module "create_db_users_lambda" {
   database_name                    = "consignmentapi"
 }
 
-module "create_bastion_user_lambda" {
-  source                           = "./tdr-terraform-modules/lambda"
-  project                          = var.project
-  common_tags                      = local.common_tags
-  lambda_create_db_users           = true
-  vpc_id                           = module.shared_vpc.vpc_id
-  private_subnet_ids               = module.shared_vpc.private_backend_checks_subnets
-  db_url                           = module.consignment_api_database.database_url
-  db_secrets_arn                   = module.consignment_api_database.database_master_user_secret_arn
-  kms_key_arn                      = module.encryption_key.kms_key_arn
-  database_security_group          = module.api_database_security_group.security_group_id
-  cloudwatch_log_retention_in_days = module.global_parameters.policy_cloudwatch_logs_retention["${local.environment}"].lambda
-  lambda_name                      = "create-bastion-user"
-  database_name                    = "bastion"
-}
-
 module "service_unavailable_lambda" {
   source                           = "./tdr-terraform-modules/lambda"
   project                          = var.project
@@ -565,7 +549,6 @@ module "export_efs" {
   policy                       = "efs_access_policy"
   policy_roles                 = jsonencode(module.consignment_export_task_role.role.arn)
   mount_target_security_groups = flatten([module.consignment_export_ecs_security_group.security_group_id])
-  bastion_role                 = module.bastion_role.role.arn
   netnum_offset                = 6
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
   vpc_cidr_block               = module.shared_vpc.vpc_cidr_block
@@ -827,16 +810,6 @@ module "athena" {
     "tdr_s3_request_errors"
   ]
 }
-// Create bastion role here so we can attach it to the EFS file system policy as you can't add roles that don't exist
-// We'll attach policies to the role when the bastion is created.
-module "bastion_role" {
-  source = "./tdr-terraform-modules/iam_role"
-  assume_role_policy = templatefile("./tdr-terraform-modules/ec2/templates/ec2_assume_role.json.tpl", {
-  account_id = data.aws_caller_identity.current.id })
-  common_tags        = local.common_tags
-  name               = "BastionEC2Role${title(local.environment)}"
-  policy_attachments = {}
-}
 
 module "create_keycloak_users_api_lambda" {
   source                           = "./tdr-terraform-modules/lambda"
@@ -1008,7 +981,6 @@ module "api_database_security_group" {
   ingress_security_group_rules = [
     { port = 5432, description = "Allow inbound access from ECS", security_group_id = module.consignment_api.ecs_task_security_group_id },
     { port = 5432, description = "Allow inbound access from database migrations", security_group_id = module.database_migrations.db_migration_security_group },
-    { port = 5432, description = "Allow inbound access from create bastion users lambda", security_group_id = module.create_bastion_user_lambda.create_users_lambda_security_group_id[0] },
     { port = 5432, description = "Allow inbound access from create users lambda", security_group_id = module.create_db_users_lambda.create_users_lambda_security_group_id[0] },
     { port = 5432, description = "Allow inbound access from export", security_group_id = module.consignment_export_ecs_security_group.security_group_id }
   ]

--- a/root.tf
+++ b/root.tf
@@ -71,7 +71,7 @@ module "consignment_api" {
   frontend_url                   = module.frontend.frontend_url
   dns_zone_name_trimmed          = local.dns_zone_name_trimmed
   db_instance_resource_id        = module.consignment_api_database.resource_id
-  create_users_security_group_id = flatten([module.create_db_users_lambda.create_users_lambda_security_group_id])
+  create_users_security_group_id = flatten([module.create_db_users_lambda.create_users_lambda_security_group_id, module.create_bastion_user_lambda.create_users_lambda_security_group_id])
   da_reference_generator_url     = local.da_reference_generator_url
   da_reference_generator_limit   = local.da_reference_generator_limit
   aws_guardduty_ecr_arn          = local.aws_guardduty_ecr_arn
@@ -407,6 +407,22 @@ module "create_db_users_lambda" {
   database_name                    = "consignmentapi"
 }
 
+module "create_bastion_user_lambda" {
+  source                           = "./tdr-terraform-modules/lambda"
+  project                          = var.project
+  common_tags                      = local.common_tags
+  lambda_create_db_users           = true
+  vpc_id                           = module.shared_vpc.vpc_id
+  private_subnet_ids               = module.shared_vpc.private_backend_checks_subnets
+  db_url                           = module.consignment_api_database.database_url
+  db_secrets_arn                   = module.consignment_api_database.database_master_user_secret_arn
+  kms_key_arn                      = module.encryption_key.kms_key_arn
+  database_security_group          = module.api_database_security_group.security_group_id
+  cloudwatch_log_retention_in_days = module.global_parameters.policy_cloudwatch_logs_retention["${local.environment}"].lambda
+  lambda_name                      = "create-bastion-user"
+  database_name                    = "bastion"
+}
+
 module "service_unavailable_lambda" {
   source                           = "./tdr-terraform-modules/lambda"
   project                          = var.project
@@ -549,6 +565,7 @@ module "export_efs" {
   policy                       = "efs_access_policy"
   policy_roles                 = jsonencode(module.consignment_export_task_role.role.arn)
   mount_target_security_groups = flatten([module.consignment_export_ecs_security_group.security_group_id])
+  bastion_role                 = module.bastion_role.role.arn
   netnum_offset                = 6
   nat_gateway_ids              = module.shared_vpc.nat_gateway_ids
   vpc_cidr_block               = module.shared_vpc.vpc_cidr_block
@@ -811,6 +828,15 @@ module "athena" {
   ]
 }
 
+module "bastion_role" {
+  source = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("./tdr-terraform-modules/ec2/templates/ec2_assume_role.json.tpl", {
+  account_id = data.aws_caller_identity.current.id })
+  common_tags        = local.common_tags
+  name               = "BastionEC2Role${title(local.environment)}"
+  policy_attachments = {}
+}
+
 module "create_keycloak_users_api_lambda" {
   source                           = "./tdr-terraform-modules/lambda"
   common_tags                      = local.common_tags
@@ -981,6 +1007,7 @@ module "api_database_security_group" {
   ingress_security_group_rules = [
     { port = 5432, description = "Allow inbound access from ECS", security_group_id = module.consignment_api.ecs_task_security_group_id },
     { port = 5432, description = "Allow inbound access from database migrations", security_group_id = module.database_migrations.db_migration_security_group },
+    { port = 5432, description = "Allow inbound access from create bastion users lambda", security_group_id = module.create_bastion_user_lambda.create_users_lambda_security_group_id[0] },
     { port = 5432, description = "Allow inbound access from create users lambda", security_group_id = module.create_db_users_lambda.create_users_lambda_security_group_id[0] },
     { port = 5432, description = "Allow inbound access from export", security_group_id = module.consignment_export_ecs_security_group.security_group_id }
   ]


### PR DESCRIPTION
All was security groups in the environments repo checked. Changed descriptions for redis, db_migration and eco_tasks groups. Left lb and end_point_security_group the same.

Checked nested repos and descriptions are accurate.

Readied bastion role as had removed from local repo.